### PR TITLE
[Feature] Parse otel config from k8s configmap and OpenTelemetryCollector CRD

### DIFF
--- a/packages/otelbin/src/components/monaco-editor/Editor.tsx
+++ b/packages/otelbin/src/components/monaco-editor/Editor.tsx
@@ -26,6 +26,7 @@ import { IconButton } from "~/components/icon-button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
 import { track } from "@vercel/analytics";
 import { useServerSideValidation } from "../validation/useServerSideValidation";
+import { extractRelayFromK8sConfigMap, isK8sConfigMap } from "./parseYaml";
 
 const firaCode = Fira_Code({
 	display: "swap",
@@ -77,7 +78,9 @@ export default function Editor({ locked, setLocked }: { locked: boolean; setLock
 		totalValidationErrors.jsYamlError == null && (totalValidationErrors.ajvErrors?.length ?? 0) === 0;
 
 	const handleEditorChange: OnChange = (value) => {
-		setCurrentConfig(value || "");
+		isK8sConfigMap(value ?? "")
+			? editorRef?.current?.getModel()?.setValue(extractRelayFromK8sConfigMap(value ?? "") ?? "")
+			: setCurrentConfig(value ?? "");
 	};
 
 	useEffect(() => {

--- a/packages/otelbin/src/components/monaco-editor/Editor.tsx
+++ b/packages/otelbin/src/components/monaco-editor/Editor.tsx
@@ -26,7 +26,7 @@ import { IconButton } from "~/components/icon-button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
 import { track } from "@vercel/analytics";
 import { useServerSideValidation } from "../validation/useServerSideValidation";
-import { extractRelayFromK8sConfigMap, isK8sConfigMap } from "./parseYaml";
+import { selectConfigType } from "./parseYaml";
 
 const firaCode = Fira_Code({
 	display: "swap",
@@ -78,9 +78,8 @@ export default function Editor({ locked, setLocked }: { locked: boolean; setLock
 		totalValidationErrors.jsYamlError == null && (totalValidationErrors.ajvErrors?.length ?? 0) === 0;
 
 	const handleEditorChange: OnChange = (value) => {
-		isK8sConfigMap(value ?? "")
-			? editorRef?.current?.getModel()?.setValue(extractRelayFromK8sConfigMap(value ?? "") ?? "")
-			: setCurrentConfig(value ?? "");
+		const configType = selectConfigType(value ?? "");
+		setCurrentConfig((configType as string) ?? "");
 	};
 
 	useEffect(() => {

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.test.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.test.ts
@@ -3,13 +3,7 @@
 
 import { describe, expect, it } from "@jest/globals";
 import type { IItem, IYamlElement } from "./parseYaml";
-import {
-	getYamlDocument,
-	extractServiceItems,
-	findPipelinesKeyValues,
-	parseYaml,
-	selectConfigType,
-} from "./parseYaml";
+import { getYamlDocument, extractServiceItems, findPipelinesKeyValues, parseYaml, selectConfigType } from "./parseYaml";
 
 //The example contains pipelines with duplicated names (otlp and batch)
 const editorBinding = {
@@ -227,27 +221,27 @@ describe("findPipelinesKeyValues", () => {
 	});
 });
 
-describe('selectConfigType', () => {
-	it('should return relay.data if the config is a valid K8s ConfigMap', () => {
+describe("selectConfigType", () => {
+	it("should return relay.data if the config is a valid K8s ConfigMap", () => {
 		const config = `
       kind: ConfigMap
       data:
         relay: testRelay
     `;
-		expect(selectConfigType(config)).toBe('testRelay');
+		expect(selectConfigType(config)).toBe("testRelay");
 	});
 
-	it('should return spec.config if the config is a valid OpenTelemetryCollector CRD', () => {
+	it("should return spec.config if the config is a valid OpenTelemetryCollector CRD", () => {
 		const config = `
       kind: OpenTelemetryCollector
       spec:
         config: testConfig
     `;
-		expect(selectConfigType(config)).toBe('testConfig');
+		expect(selectConfigType(config)).toBe("testConfig");
 	});
 
-	it('should return the original config if it is not a valid K8s ConfigMap or OpenTelemetryCollector CRD', () => {
-		const config = 'invalidConfig';
+	it("should return the original config if it is not a valid K8s ConfigMap or OpenTelemetryCollector CRD", () => {
+		const config = "invalidConfig";
 		expect(selectConfigType(config)).toBe(config);
 	});
 });

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.test.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.test.ts
@@ -3,7 +3,13 @@
 
 import { describe, expect, it } from "@jest/globals";
 import type { IItem, IYamlElement } from "./parseYaml";
-import { getYamlDocument, extractServiceItems, findPipelinesKeyValues, parseYaml } from "./parseYaml";
+import {
+	getYamlDocument,
+	extractServiceItems,
+	findPipelinesKeyValues,
+	parseYaml,
+	extractRelayFromK8sConfigMap,
+} from "./parseYaml";
 
 //The example contains pipelines with duplicated names (otlp and batch)
 const editorBinding = {
@@ -218,5 +224,35 @@ describe("findPipelinesKeyValues", () => {
 		const result = findPipelinesKeyValues();
 
 		expect(result).toEqual({});
+	});
+});
+
+describe("extractRelayFromK8sConfigMap", () => {
+	it("should return relay data if the config is a valid K8s ConfigMap", () => {
+		const config = `
+kind: ConfigMap
+data:
+  relay: testRelay
+    `;
+		expect(extractRelayFromK8sConfigMap(config)).toBe("testRelay");
+	});
+
+	it('should return relay data if the config is a valid K8s ConfigMap with case insensitive "kind: configmap"', () => {
+		const config = `
+kind: configmap
+data:
+  relay: testRelay
+    `;
+		expect(extractRelayFromK8sConfigMap(config)).toBe("testRelay");
+	});
+
+	it("should return the original config if it is not a valid K8s ConfigMap", () => {
+		const config = "invalidConfig";
+		expect(extractRelayFromK8sConfigMap(config)).toBe(config);
+	});
+
+	it("should return empty string if the config is empty", () => {
+		const config = "";
+		expect(extractRelayFromK8sConfigMap(config)).toBe("");
 	});
 });

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.test.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.test.ts
@@ -8,7 +8,7 @@ import {
 	extractServiceItems,
 	findPipelinesKeyValues,
 	parseYaml,
-	extractRelayFromK8sConfigMap,
+	selectConfigType,
 } from "./parseYaml";
 
 //The example contains pipelines with duplicated names (otlp and batch)
@@ -227,32 +227,27 @@ describe("findPipelinesKeyValues", () => {
 	});
 });
 
-describe("extractRelayFromK8sConfigMap", () => {
-	it("should return relay data if the config is a valid K8s ConfigMap", () => {
+describe('selectConfigType', () => {
+	it('should return relay.data if the config is a valid K8s ConfigMap', () => {
 		const config = `
-kind: ConfigMap
-data:
-  relay: testRelay
+      kind: ConfigMap
+      data:
+        relay: testRelay
     `;
-		expect(extractRelayFromK8sConfigMap(config)).toBe("testRelay");
+		expect(selectConfigType(config)).toBe('testRelay');
 	});
 
-	it('should return relay data if the config is a valid K8s ConfigMap with case insensitive "kind: configmap"', () => {
+	it('should return spec.config if the config is a valid OpenTelemetryCollector CRD', () => {
 		const config = `
-kind: configmap
-data:
-  relay: testRelay
+      kind: OpenTelemetryCollector
+      spec:
+        config: testConfig
     `;
-		expect(extractRelayFromK8sConfigMap(config)).toBe("testRelay");
+		expect(selectConfigType(config)).toBe('testConfig');
 	});
 
-	it("should return the original config if it is not a valid K8s ConfigMap", () => {
-		const config = "invalidConfig";
-		expect(extractRelayFromK8sConfigMap(config)).toBe(config);
-	});
-
-	it("should return empty string if the config is empty", () => {
-		const config = "";
-		expect(extractRelayFromK8sConfigMap(config)).toBe("");
+	it('should return the original config if it is not a valid K8s ConfigMap or OpenTelemetryCollector CRD', () => {
+		const config = 'invalidConfig';
+		expect(selectConfigType(config)).toBe(config);
 	});
 });

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Parser } from "yaml";
-
+import JsYaml from "js-yaml";
 export interface SourceToken {
 	type:
 		| "byte-order-mark"
@@ -74,6 +74,13 @@ export interface ILeaf {
 
 export interface IValidateItem {
 	[key: string]: ILeaf[];
+}
+
+export interface IK8sObject {
+	kind?: string;
+	data?: {
+		relay?: string;
+	};
 }
 
 export const getYamlDocument = (editorValue: string) => {
@@ -213,4 +220,15 @@ export function findLineAndColumn(config: string, targetOffset?: number) {
 	}
 
 	return { line: lineIndex, column };
+}
+
+export function isK8sConfigMap(config: string) {
+	const jsonData = JsYaml.load(config) as IK8sObject;
+	const isConfigMap = jsonData?.kind === "ConfigMap";
+	return jsonData && jsonData?.data?.relay && isConfigMap ? true : false;
+}
+
+export function extractRelayFromK8sConfigMap(config: string): string | undefined {
+	const jsonData = JsYaml.load(config) as IK8sObject;
+	return isK8sConfigMap(config) ? jsonData?.data?.relay : config;
 }

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -5,25 +5,25 @@ import { Parser } from "yaml";
 import JsYaml from "js-yaml";
 export interface SourceToken {
 	type:
-		| "byte-order-mark"
-		| "doc-mode"
-		| "doc-start"
-		| "space"
-		| "comment"
-		| "newline"
-		| "directive-line"
-		| "anchor"
-		| "tag"
-		| "seq-item-ind"
-		| "explicit-key-ind"
-		| "map-value-ind"
-		| "flow-map-start"
-		| "flow-map-end"
-		| "flow-seq-start"
-		| "flow-seq-end"
-		| "flow-error-end"
-		| "comma"
-		| "block-scalar-header";
+	| "byte-order-mark"
+	| "doc-mode"
+	| "doc-start"
+	| "space"
+	| "comment"
+	| "newline"
+	| "directive-line"
+	| "anchor"
+	| "tag"
+	| "seq-item-ind"
+	| "explicit-key-ind"
+	| "map-value-ind"
+	| "flow-map-start"
+	| "flow-map-end"
+	| "flow-seq-start"
+	| "flow-seq-end"
+	| "flow-error-end"
+	| "comma"
+	| "block-scalar-header";
 	offset: number;
 	indent: number;
 	source: string;
@@ -224,7 +224,7 @@ export function findLineAndColumn(config: string, targetOffset?: number) {
 
 export function isK8sConfigMap(config: string) {
 	const jsonData = JsYaml.load(config) as IK8sObject;
-	const isConfigMap = jsonData?.kind?.toLocaleLowerCase() === "configmap";
+	const isConfigMap = jsonData?.kind?.toLowerCase() === "configmap";
 	return jsonData && jsonData?.data?.relay && isConfigMap ? true : false;
 }
 

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -224,7 +224,7 @@ export function findLineAndColumn(config: string, targetOffset?: number) {
 
 export function isK8sConfigMap(config: string) {
 	const jsonData = JsYaml.load(config) as IK8sObject;
-	const isConfigMap = jsonData?.kind === "ConfigMap";
+	const isConfigMap = jsonData?.kind?.toLocaleLowerCase() === "configmap";
 	return jsonData && jsonData?.data?.relay && isConfigMap ? true : false;
 }
 

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -5,25 +5,25 @@ import { Parser } from "yaml";
 import JsYaml from "js-yaml";
 export interface SourceToken {
 	type:
-	| "byte-order-mark"
-	| "doc-mode"
-	| "doc-start"
-	| "space"
-	| "comment"
-	| "newline"
-	| "directive-line"
-	| "anchor"
-	| "tag"
-	| "seq-item-ind"
-	| "explicit-key-ind"
-	| "map-value-ind"
-	| "flow-map-start"
-	| "flow-map-end"
-	| "flow-seq-start"
-	| "flow-seq-end"
-	| "flow-error-end"
-	| "comma"
-	| "block-scalar-header";
+		| "byte-order-mark"
+		| "doc-mode"
+		| "doc-start"
+		| "space"
+		| "comment"
+		| "newline"
+		| "directive-line"
+		| "anchor"
+		| "tag"
+		| "seq-item-ind"
+		| "explicit-key-ind"
+		| "map-value-ind"
+		| "flow-map-start"
+		| "flow-map-end"
+		| "flow-seq-start"
+		| "flow-seq-end"
+		| "flow-error-end"
+		| "comma"
+		| "block-scalar-header";
 	offset: number;
 	indent: number;
 	source: string;
@@ -80,6 +80,13 @@ export interface IK8sObject {
 	kind?: string;
 	data?: {
 		relay?: string;
+	};
+}
+
+export interface IOtelColCRD {
+	kind?: string;
+	spec?: {
+		config?: string;
 	};
 }
 
@@ -222,13 +229,24 @@ export function findLineAndColumn(config: string, targetOffset?: number) {
 	return { line: lineIndex, column };
 }
 
-export function isK8sConfigMap(config: string) {
-	const jsonData = JsYaml.load(config) as IK8sObject;
+export function isK8sConfigMap(jsonData: IK8sObject) {
 	const isConfigMap = jsonData?.kind?.toLowerCase() === "configmap";
 	return jsonData && jsonData?.data?.relay && isConfigMap ? true : false;
 }
 
-export function extractRelayFromK8sConfigMap(config: string) {
-	const jsonData = JsYaml.load(config) as IK8sObject;
-	return isK8sConfigMap(config) ? jsonData?.data?.relay : config;
+export function isOtelColCRD(jsonData: IOtelColCRD) {
+	const isOtelColCRD = jsonData?.kind === "OpenTelemetryCollector";
+	return jsonData && jsonData?.spec?.config && isOtelColCRD ? true : false;
+}
+
+export function selectConfigType(config: string) {
+	const jsonData = JsYaml.load(config) as any;
+
+	if (isK8sConfigMap(jsonData)) {
+		return jsonData.data.relay;
+	} else if (isOtelColCRD(jsonData)) {
+		return jsonData.spec.config;
+	} else {
+		return config;
+	}
 }

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -228,7 +228,7 @@ export function isK8sConfigMap(config: string) {
 	return jsonData && jsonData?.data?.relay && isConfigMap ? true : false;
 }
 
-export function extractRelayFromK8sConfigMap(config: string): string | undefined {
+export function extractRelayFromK8sConfigMap(config: string) {
 	const jsonData = JsYaml.load(config) as IK8sObject;
 	return isK8sConfigMap(config) ? jsonData?.data?.relay : config;
 }

--- a/packages/otelbin/src/contexts/EditorContext.tsx
+++ b/packages/otelbin/src/contexts/EditorContext.tsx
@@ -10,7 +10,7 @@ import schema from "../components/monaco-editor/schema.json";
 import { fromPosition, toCompletionList } from "monaco-languageserver-types";
 import { type languages } from "monaco-editor/esm/vs/editor/editor.api.js";
 import type { IItem } from "../components/monaco-editor/parseYaml";
-import { getYamlDocument } from "../components/monaco-editor/parseYaml";
+import { extractRelayFromK8sConfigMap, getYamlDocument } from "../components/monaco-editor/parseYaml";
 import { type WorkerGetter, createWorkerManager } from "monaco-worker-manager";
 import { type CompletionList, type Position } from "vscode-languageserver-types";
 import { validateOtelCollectorConfigurationAndSetMarkers } from "~/components/monaco-editor/otelCollectorConfigValidation";
@@ -244,6 +244,11 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
 				endColumn: 0,
 			};
 			findSymbols(docElements, "", wordAtCursor.word, cursorOffset);
+		});
+
+		editorRef.current.onDidPaste(() => {
+			const currentConfig = editorRef.current?.getModel()?.getValue() || "";
+			editorRef.current?.getModel()?.setValue(extractRelayFromK8sConfigMap(currentConfig) ?? "");
 		});
 	}
 

--- a/packages/otelbin/src/contexts/EditorContext.tsx
+++ b/packages/otelbin/src/contexts/EditorContext.tsx
@@ -10,7 +10,7 @@ import schema from "../components/monaco-editor/schema.json";
 import { fromPosition, toCompletionList } from "monaco-languageserver-types";
 import { type languages } from "monaco-editor/esm/vs/editor/editor.api.js";
 import type { IItem } from "../components/monaco-editor/parseYaml";
-import { extractRelayFromK8sConfigMap, getYamlDocument } from "../components/monaco-editor/parseYaml";
+import { getYamlDocument, selectConfigType } from "../components/monaco-editor/parseYaml";
 import { type WorkerGetter, createWorkerManager } from "monaco-worker-manager";
 import { type CompletionList, type Position } from "vscode-languageserver-types";
 import { validateOtelCollectorConfigurationAndSetMarkers } from "~/components/monaco-editor/otelCollectorConfigValidation";
@@ -248,7 +248,8 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
 
 		editorRef.current.onDidPaste(() => {
 			const currentConfig = editorRef.current?.getModel()?.getValue() || "";
-			editorRef.current?.getModel()?.setValue(extractRelayFromK8sConfigMap(currentConfig) ?? "");
+			const configType = selectConfigType(currentConfig);
+			editorRef.current?.getModel()?.setValue((configType as string) ?? "");
 		});
 	}
 


### PR DESCRIPTION
This pull request addresses the issue #99.

### Changes Made
- Added a new feature to automatically that extracts `data.relay` from K8s ConfigMaps and `spec.config` from OpenTelemetryCollector CRD, pasted into OtelBin.
- Introduced the `selectConfigType` function to handle for selecting the correct config type.
- Updated test cases to cover the new functionality.

### How to Test
1. Copy a K8s ConfigMap containing Otel configuration or a OpenTelemetryCollector CRD.
2. Paste it into OtelBin.
3. Verify that the `data.relay` or `spec.config` is automatically extracted and visualized otel-col pipelines.

## Screenshots (if applicable)

## Checklist
- [x] Tests added and passing
- [x] Code follows the project's style guidelines
