### PR TITLE
Fix: Calculation of Scale for Maximum Processors in a Row for social media image

### DIFF
--- a/packages/otelbin/src/app/og/Node.tsx
+++ b/packages/otelbin/src/app/og/Node.tsx
@@ -41,14 +41,7 @@ const Node = ({ data, icon, type }: { data: IData; icon: React.ReactNode; type: 
 	const isConnector = data.type.includes("connectors");
 
 	return (
-		<div
-			style={{
-				display: "flex",
-				marginLeft: "10px",
-				marginRight: "10px",
-			}}
-			tw={`h-[72px] w-[110px] flex-col items-center rounded-lg my-5 `}
-		>
+		<div tw={`h-[72px] w-[110px] flex-col items-center rounded-lg my-5 mx-[10px] flex`}>
 			<div
 				style={customNodeHeaderStyle}
 				tw={`px-3  text-xs font-medium h-[35%] w-full flex items-center justify-center text-white

--- a/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
+++ b/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
@@ -50,13 +50,19 @@ describe("calcScale", () => {
 		const nodes: Node[] = [
 			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
 			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
-			{ type: "processorsNode", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
-			{ type: "processorsNode", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
+			{ type: "processorsNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
+			{ type: "processorsNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "6" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "7" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "8" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "9" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "10" },
 		];
 
 		const edgeWidth = 10;
 		const scale = calcScale(edgeWidth, nodes);
-		expect(scale).toBe("1.270");
+		expect(scale).toBe("0.976");
 	});
 
 	it("Should return 1 if there is no node.", () => {

--- a/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
+++ b/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
@@ -65,6 +65,48 @@ describe("calcScale", () => {
 		expect(scale).toBe("0.976");
 	});
 
+	it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
+		const nodes: Node[] = [
+			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
+			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
+			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
+			{ type: "receiversNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
+		];
+
+		const edgeWidth = 10;
+		const scale = calcScale(edgeWidth, nodes);
+		expect(scale).toBe("1.270");
+	});
+
+	it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
+		const nodes: Node[] = [
+			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
+			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
+			{ type: "exportersNode", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
+			{ type: "connectors/exporters", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
+			{ type: "receiversNode", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
+		];
+
+		const edgeWidth = 10;
+		const scale = calcScale(edgeWidth, nodes);
+		expect(scale).toBe("1.270");
+	});
+
+	it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
+		const nodes: Node[] = [
+			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
+			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
+			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
+			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
+			{ type: "connectors/receivers", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
+			{ type: "receiversNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "6" },
+		];
+
+		const edgeWidth = 10;
+		const scale = calcScale(edgeWidth, nodes);
+		expect(scale).toBe("1.270");
+	});
+
 	it("Should return 1 if there is no node.", () => {
 		const nodes: Node[] = [];
 

--- a/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
+++ b/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
@@ -57,49 +57,61 @@ describe("calcScale", () => {
 
 	runTest(
 		[
-			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
-			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
-			{ type: "processorsNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
-			{ type: "processorsNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
-			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
-			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "6" },
-			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "7" },
-			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "8" },
-			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "9" },
-			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "10" },
+			{ type: "parentNodeType", data: { height: 100 }, position: { x: 100, y: 200 }, id: "1" },
+			{ type: "parentNodeType", data: { height: 200 }, position: { x: 200, y: 300 }, id: "2" },
+			{ type: "processorsNode", parentNode: "metrics", data: { height: 100 }, position: { x: 200, y: 300 }, id: "3" },
+			{ type: "processorsNode", parentNode: "metrics", data: { height: 100 }, position: { x: 210, y: 220 }, id: "4" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 10 }, id: "5" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 200 }, position: { x: 10, y: 20 }, id: "6" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 300 }, position: { x: 20, y: 30 }, id: "7" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 400 }, position: { x: 30, y: 40 }, id: "8" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 500 }, position: { x: 40, y: 50 }, id: "9" },
+			{ type: "processorsNode", parentNode: "logs", data: { height: 600 }, position: { x: 50, y: 60 }, id: "10" },
 		],
 		"0.976"
 	);
 
 	runTest(
 		[
-			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
-			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
+			{ type: "parentNodeType", data: { height: 100 }, position: { x: 70, y: 80 }, id: "1" },
+			{ type: "parentNodeType", data: { height: 200 }, position: { x: 80, y: 90 }, id: "2" },
 			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
-			{ type: "receiversNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
+			{ type: "receiversNode", parentNode: "logs", data: { height: 200 }, position: { x: 0, y: 0 }, id: "4" },
 		],
 		"1.270"
 	);
 
 	runTest(
 		[
-			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
-			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
-			{ type: "exportersNode", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
-			{ type: "connectors/exporters", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
-			{ type: "receiversNode", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
+			{ type: "parentNodeType", data: { height: 100 }, position: { x: 100, y: 110 }, id: "1" },
+			{ type: "parentNodeType", data: { height: 200 }, position: { x: 110, y: 120 }, id: "2" },
+			{ type: "exportersNode", parentNode: "traces", data: { height: 100 }, position: { x: 120, y: 130 }, id: "3" },
+			{
+				type: "connectors/exporters",
+				parentNode: "traces",
+				data: { height: 100 },
+				position: { x: 130, y: 140 },
+				id: "4",
+			},
+			{ type: "receiversNode", parentNode: "traces", data: { height: 100 }, position: { x: 140, y: 150 }, id: "5" },
 		],
 		"1.270"
 	);
 
 	runTest(
 		[
-			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
-			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
-			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
-			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
-			{ type: "connectors/receivers", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
-			{ type: "receiversNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "6" },
+			{ type: "parentNodeType", data: { height: 100 }, position: { x: 150, y: 160 }, id: "1" },
+			{ type: "parentNodeType", data: { height: 200 }, position: { x: 160, y: 170 }, id: "2" },
+			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 170, y: 180 }, id: "3" },
+			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 180, y: 190 }, id: "4" },
+			{
+				type: "connectors/receivers",
+				parentNode: "metrics",
+				data: { height: 100 },
+				position: { x: 190, y: 200 },
+				id: "5",
+			},
+			{ type: "receiversNode", parentNode: "metrics", data: { height: 100 }, position: { x: 200, y: 210 }, id: "6" },
 		],
 		"1.270"
 	);

--- a/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
+++ b/packages/otelbin/src/app/s/[id]/metadataUtils.test.ts
@@ -46,8 +46,17 @@ describe("extractComponents", () => {
 });
 
 describe("calcScale", () => {
-	it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
-		const nodes: Node[] = [
+	const edgeWidth = 10;
+
+	const runTest = (nodes: Node[], expectedScale: string) => {
+		it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
+			const scale = calcScale(edgeWidth, nodes);
+			expect(scale).toBe(expectedScale);
+		});
+	};
+
+	runTest(
+		[
 			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
 			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
 			{ type: "processorsNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
@@ -58,62 +67,44 @@ describe("calcScale", () => {
 			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "8" },
 			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "9" },
 			{ type: "processorsNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "10" },
-		];
+		],
+		"0.976"
+	);
 
-		const edgeWidth = 10;
-		const scale = calcScale(edgeWidth, nodes);
-		expect(scale).toBe("0.976");
-	});
-
-	it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
-		const nodes: Node[] = [
+	runTest(
+		[
 			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
 			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
 			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
 			{ type: "receiversNode", parentNode: "logs", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
-		];
+		],
+		"1.270"
+	);
 
-		const edgeWidth = 10;
-		const scale = calcScale(edgeWidth, nodes);
-		expect(scale).toBe("1.270");
-	});
-
-	it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
-		const nodes: Node[] = [
+	runTest(
+		[
 			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
 			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
 			{ type: "exportersNode", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
 			{ type: "connectors/exporters", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
 			{ type: "receiversNode", parentNode: "traces", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
-		];
+		],
+		"1.270"
+	);
 
-		const edgeWidth = 10;
-		const scale = calcScale(edgeWidth, nodes);
-		expect(scale).toBe("1.270");
-	});
-
-	it("Should calculate the correct scale based on the maximum height or width of the visualization nodes to ensure they fit within the standard 1200x630 size of the generated Open Graph image.", () => {
-		const nodes: Node[] = [
+	runTest(
+		[
 			{ type: "parentNodeType", data: { height: 100 }, position: { x: 0, y: 0 }, id: "1" },
 			{ type: "parentNodeType", data: { height: 200 }, position: { x: 0, y: 0 }, id: "2" },
 			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "3" },
 			{ type: "exportersNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "4" },
 			{ type: "connectors/receivers", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "5" },
 			{ type: "receiversNode", parentNode: "metrics", data: { height: 100 }, position: { x: 0, y: 0 }, id: "6" },
-		];
+		],
+		"1.270"
+	);
 
-		const edgeWidth = 10;
-		const scale = calcScale(edgeWidth, nodes);
-		expect(scale).toBe("1.270");
-	});
-
-	it("Should return 1 if there is no node.", () => {
-		const nodes: Node[] = [];
-
-		const edgeWidth = 10;
-		const scale = calcScale(edgeWidth, nodes);
-		expect(scale).toBe("1");
-	});
+	runTest([], "1");
 });
 
 describe("toUrlState", () => {

--- a/packages/otelbin/src/app/s/[id]/metadataUtils.ts
+++ b/packages/otelbin/src/app/s/[id]/metadataUtils.ts
@@ -33,14 +33,29 @@ export function extractComponents(jsonData: IConfig) {
 
 export function calcScale(edgeWidth: number, nodes?: Node[]) {
 	if (nodes?.length === 0 || !nodes) return "1";
+	const processorsCount = {} as Record<string, number>;
+	const nodesWidth = 140;
+	const parentNodesPadding = 40;
 	const targetHeight = 630;
 	const targetWidth = 1200;
 	const parentNodes = nodes?.filter((node) => node.type === "parentNodeType");
-	const processors = nodes?.filter((node) => node.type === "processorsNode");
+	const processors = nodes?.filter((node) => node.type === "processorsNode") ?? [];
+	const processorPipelines = processors.map((node) => node.parentNode) ?? [];
+	if (processorPipelines) {
+		processorPipelines.forEach((pipeline) => {
+			if (pipeline && pipeline in processorsCount) {
+				processorsCount[pipeline] += 1;
+			} else if (pipeline) {
+				processorsCount[pipeline] = 1;
+			}
+		});
+	}
+	const maxProcessorPipelineCount = Math.max(...Object.values(processorsCount));
 	const nodesHeight = parentNodes?.map((node) => node.data.height) ?? [0];
 	const totalHeight = nodesHeight?.reduce((sum, height) => sum + (height + 50), 0) + 4 * 24;
-	const totalHorizontalNodesCount = (processors?.length ?? 0) + 2;
-	const totalWidth = totalHorizontalNodesCount * 140 + (totalHorizontalNodesCount - 1) * edgeWidth;
+	const totalHorizontalNodesCount = maxProcessorPipelineCount + 2;
+	const totalWidth =
+		totalHorizontalNodesCount * nodesWidth + (totalHorizontalNodesCount - 1) * edgeWidth + parentNodesPadding;
 	const scale = Math.min(targetHeight / totalHeight, targetWidth / totalWidth).toFixed(3);
 	return scale.toString();
 }

--- a/packages/otelbin/src/app/s/[id]/metadataUtils.ts
+++ b/packages/otelbin/src/app/s/[id]/metadataUtils.ts
@@ -40,8 +40,8 @@ export function calcScale(edgeWidth: number, nodes?: Node[]) {
 	const targetWidth = 1200;
 	const parentNodes = nodes?.filter((node) => node.type === "parentNodeType");
 	const processors = nodes?.filter((node) => node.type === "processorsNode") ?? [];
-	const processorPipelines = processors.map((node) => node.parentNode) ?? [];
-	if (processorPipelines) {
+	const processorPipelines = processors.length > 0 ? processors.map((node) => node.parentNode) : [];
+	if (processorPipelines.length > 0) {
 		processorPipelines.forEach((pipeline) => {
 			if (pipeline && pipeline in processorsCount) {
 				processorsCount[pipeline] += 1;
@@ -49,6 +49,8 @@ export function calcScale(edgeWidth: number, nodes?: Node[]) {
 				processorsCount[pipeline] = 1;
 			}
 		});
+	} else {
+		processorsCount["default"] = processors.length;
 	}
 	const maxProcessorPipelineCount = Math.max(...Object.values(processorsCount));
 	const nodesHeight = parentNodes?.map((node) => node.data.height) ?? [0];

--- a/packages/otelbin/src/components/share/ShareContent.tsx
+++ b/packages/otelbin/src/components/share/ShareContent.tsx
@@ -15,7 +15,6 @@ import { useToast } from "~/components/use-toast";
 import { fetcher } from "~/lib/fetcher";
 import useSWRImmutable from "swr/immutable";
 import { useState } from "react";
-import { cn } from "~/lib/utils";
 
 export function ShareContent() {
 	const { toast } = useToast();


### PR DESCRIPTION
This pull request addresses an issue related to the calculation of the scale for determining the maximum number of processors displayed in a row for social media images. The current implementation may not accurately represent the optimal scaling, leading to irregularities in the social media image output.

Screenshots:
![img (3)](https://github.com/dash0hq/otelbin/assets/76537930/f01c2554-935b-4bf3-a462-ea5567e8cb61)
![img (2)](https://github.com/dash0hq/otelbin/assets/76537930/f2caa0f0-302e-4059-b073-1e9b631ad638)
![img (4)](https://github.com/dash0hq/otelbin/assets/76537930/62f1ef57-6706-41e8-84fa-c42137d8f7dd)
