### PR TITLE
OTelBin crashes when the name of a pipeline component is a number

### DIFF
--- a/packages/otelbin/src/app/s/[id]/img/route.tsx
+++ b/packages/otelbin/src/app/s/[id]/img/route.tsx
@@ -8,7 +8,7 @@ import { Redis } from "@upstash/redis/nodejs";
 import { getShortLinkPersistenceKey } from "~/lib/shortLink";
 import type { IConfig } from "~/components/react-flow/dataType";
 import { editorBinding } from "~/components/monaco-editor/editorBinding";
-import JsYaml from "js-yaml";
+import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
 import { calcScale, toUrlState } from "../metadataUtils";
 import Logo from "~/components/assets/svg/otelbin_logo_white.svg";
 import { notFound } from "next/navigation";
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
 		return new NextResponse("Invalid short link ID", { status: 400 });
 	}
 	const { config } = toUrlState(url, [editorBinding]);
-	const jsonData = JsYaml.load(config) as IConfig;
+	const jsonData = JsYaml.load(config, { schema: FAILSAFE_SCHEMA }) as IConfig;
 	const initNodes = calcNodes(jsonData, true);
 	const parentNodes = initNodes?.filter((node) => node.type === "parentNodeType");
 

--- a/packages/otelbin/src/app/s/[id]/preview/page.tsx
+++ b/packages/otelbin/src/app/s/[id]/preview/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next";
 import type { IConfig } from "~/components/react-flow/dataType";
 import { getShortLinkPersistenceKey } from "~/lib/shortLink";
 import { editorBinding } from "~/components/monaco-editor/editorBinding";
-import JsYaml from "js-yaml";
+import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
 import { extractComponents, sortAndDeduplicate, toUrlState } from "~/app/s/[id]/metadataUtils";
 import { notFound } from "next/navigation";
 
@@ -40,7 +40,7 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
 		const url = new URL(fullLink);
 		const imagesUrl = new URL(`/s/${params.id}/img`, url.origin);
 		const { config } = toUrlState(url, [editorBinding]);
-		const jsonData = JsYaml.load(config) as IConfig;
+		const jsonData = JsYaml.load(config, { schema: FAILSAFE_SCHEMA }) as IConfig;
 		const components = extractComponents(jsonData);
 		const pipelines = Object.keys(jsonData?.service?.pipelines ?? {});
 		extendedMetadata.twitterData1 = sortAndDeduplicate(components);

--- a/packages/otelbin/src/components/monaco-editor/otelCollectorConfigValidation.ts
+++ b/packages/otelbin/src/components/monaco-editor/otelCollectorConfigValidation.ts
@@ -3,7 +3,7 @@
 
 import { schema } from "./JSONSchema";
 import type { IAjvError, IError, IJsYamlError } from "./ValidationErrorConsole";
-import JsYaml from "js-yaml";
+import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
 import Ajv from "ajv";
 import type { ErrorObject } from "ajv";
 import type { RefObject } from "react";
@@ -52,7 +52,7 @@ export function validateOtelCollectorConfigurationAndSetMarkers(
 	const serverSideValidationPath = serverSideValidationResult?.result?.path ?? [];
 
 	try {
-		const jsonData = JsYaml.load(configData);
+		const jsonData = JsYaml.load(configData, { schema: FAILSAFE_SCHEMA });
 		const valid = ajv.validate(schema, jsonData);
 		if (!valid) {
 			const errors = ajv.errors;

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Parser } from "yaml";
-import JsYaml from "js-yaml";
+import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
 export interface SourceToken {
 	type:
 		| "byte-order-mark"
@@ -240,7 +240,7 @@ export function isOtelColCRD(jsonData: IOtelColCRD) {
 }
 
 export function selectConfigType(config: string) {
-	const jsonData = JsYaml.load(config) as any;
+	const jsonData = JsYaml.load(config, { schema: FAILSAFE_SCHEMA }) as any;
 
 	if (isK8sConfigMap(jsonData)) {
 		return jsonData.data.relay;

--- a/packages/otelbin/src/components/react-flow/ReactFlow.tsx
+++ b/packages/otelbin/src/components/react-flow/ReactFlow.tsx
@@ -5,7 +5,7 @@ import React, { type RefObject, useEffect, useMemo } from "react";
 import ReactFlow, { Background, Panel, useReactFlow, useNodesState, useEdgesState, useStore } from "reactflow";
 import "reactflow/dist/style.css";
 import type { IConfig } from "./dataType";
-import { parse, Parser } from "yaml";
+import { Parser } from "yaml";
 import useEdgeCreator from "./useEdgeCreator";
 import { useFocus } from "~/contexts/EditorContext";
 import { Minus, Plus, HelpCircle, Lock, Minimize2 } from "lucide-react";
@@ -22,6 +22,7 @@ import ReceiversNode from "./node-types/ReceiversNode";
 import ProcessorsNode from "./node-types/ProcessorsNode";
 import { useLayout } from "./layout/useLayout";
 import CyclicErrorEdge from "./CyclicErrorEdge";
+import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
 
 type EditorRefType = RefObject<editor.IStandaloneCodeEditor | null>;
 
@@ -39,7 +40,7 @@ export default function Flow({
 	editorRef: EditorRefType | null;
 }) {
 	const reactFlowInstance = useReactFlow();
-	const jsonData = useMemo(() => parse(value) as IConfig, [value]);
+	const jsonData = useMemo(() => JsYaml.load(value, { schema: FAILSAFE_SCHEMA }) as IConfig, [value]);
 	const pipelines = useMemo(() => {
 		const parsedYaml = Array.from(new Parser().parse(value));
 		const doc = parsedYaml.find((token) => token.type === "document") as Document;


### PR DESCRIPTION
**Issue**:
The root cause of the issue was traced back to the YAML parser (JSYaml), specifically in its interpretation of numerical names. When processing names like "123," the parser converted them into actual numbers. This behavior conflicted with the expectation that names remain as strings, leading to a crash in scenarios where numerical names were involved.

**Fix**:
After investigating the issue and referring to the [js-yaml documentation](https://github.com/nodeca/js-yaml?tab=readme-ov-file#api), it was discovered that configuring js-yaml with schema: FAILSAFE_SCHEMA is intended to restrict the output to only include strings, arrays, and plain objects. To address the problem, this pull request adjusts the YAML parser options to circumvent the inclusion of real numbers in the JSON output. By doing so, it ensures that the output retains the necessary string format for names.

