### PR TITLE
fix: paste event resets the cursor position

### DIFF
--- a/packages/otelbin/src/contexts/EditorContext.tsx
+++ b/packages/otelbin/src/contexts/EditorContext.tsx
@@ -249,7 +249,9 @@ export const EditorProvider = ({ children }: { children: ReactNode }) => {
 		editorRef.current.onDidPaste(() => {
 			const currentConfig = editorRef.current?.getModel()?.getValue() || "";
 			const configType = selectConfigType(currentConfig);
-			editorRef.current?.getModel()?.setValue((configType as string) ?? "");
+			if (configType !== currentConfig) {
+				editorRef.current?.getModel()?.setValue((configType as string) ?? "");
+			}
 		});
 	}
 


### PR DESCRIPTION
**Issue**:
Pasting content into the editor was causing the cursor to unexpectedly move to the top of line 0, column 0.

**Changes**:
This pull request addresses the cursor movement issue during the paste operation. The fix ensures that the cursor retains its position after pasting content, preventing it from jumping to the beginning of the document.