### PR TITLE
fix: Click on the visualization node with no definition

### DIFF
--- a/packages/otelbin/src/components/react-flow/FlowClick.ts
+++ b/packages/otelbin/src/components/react-flow/FlowClick.ts
@@ -64,7 +64,12 @@ export function FlowClick(
 				?.filter((item) => item.level1Parent === data.parentNode)
 				.find((item) => item.source === label);
 		} else {
-			return mainItemsData[dataType]?.find((item) => item.source === label);
+			return (
+				mainItemsData[dataType]?.find((item) => item.source === label) ??
+				pipelinesKeyValues?.[dataType]
+					?.filter((item) => item.level1Parent === data.parentNode)
+					.find((item) => item.source === label)
+			);
 		}
 	}
 


### PR DESCRIPTION
This pull request addresses the issue where clicking on a visualization item with no associated definition resulted in unexpected behavior. The fix ensures that, in such cases, the cursor in editor is correctly navigated to the dangling reference of the visualization item.