### PR TITLE
Fix YAML Config Editing Console Runtime Errors by Switching to Yaml Library

### DIFF
--- a/packages/otelbin/src/components/monaco-editor/Editor.tsx
+++ b/packages/otelbin/src/components/monaco-editor/Editor.tsx
@@ -74,8 +74,7 @@ export default function Editor({ locked, setLocked }: { locked: boolean; setLock
 		}
 	}, [currentConfig, editorRef, monacoRef, serverSideValidationResult]);
 
-	const isValidConfig =
-		totalValidationErrors.jsYamlError == null && (totalValidationErrors.ajvErrors?.length ?? 0) === 0;
+	const isValidConfig = totalValidationErrors.yamlError == null && (totalValidationErrors.ajvErrors?.length ?? 0) === 0;
 
 	const handleEditorChange: OnChange = (value) => {
 		const configType = selectConfigType(value ?? "");

--- a/packages/otelbin/src/components/monaco-editor/ValidationErrorConsole.tsx
+++ b/packages/otelbin/src/components/monaco-editor/ValidationErrorConsole.tsx
@@ -192,7 +192,7 @@ export function ErrorMessage({
 			{yamlError ? (
 				<div className={`${font.className} ${errorsStyle}`}>
 					<p className="max-w-[100%]">{`${yamlError.code} ${
-						yamlError.pos && `(Line ${yamlError.linePos?.[0].line})`
+						yamlError.linePos && `(Line ${yamlError.linePos?.[0].line})`
 					}`}</p>
 				</div>
 			) : (

--- a/packages/otelbin/src/components/monaco-editor/ValidationErrorConsole.tsx
+++ b/packages/otelbin/src/components/monaco-editor/ValidationErrorConsole.tsx
@@ -4,17 +4,11 @@
 import { useEffect, useState, useRef } from "react";
 import { ChevronDown, XCircle, AlertTriangle } from "lucide-react";
 import { type NextFont } from "next/dist/compiled/@next/font";
+import type { YAMLParseError } from "yaml";
 
 export interface IAjvError {
 	message: string;
 	line?: number | null;
-}
-
-export interface IJsYamlError {
-	mark: {
-		line: number | null;
-	};
-	reason: string | null;
 }
 
 export interface IServerSideError {
@@ -25,7 +19,7 @@ export interface IServerSideError {
 }
 
 export interface IError {
-	jsYamlError?: IJsYamlError;
+	yamlError?: YAMLParseError;
 	ajvErrors?: IAjvError[];
 	customErrors?: string[];
 	customWarnings?: string[];
@@ -43,7 +37,7 @@ export default function ValidationErrorConsole({ errors, font }: { errors?: IErr
 	const [height, setHeight] = useState(170);
 	const errorCount =
 		(errors?.ajvErrors?.length ?? 0) +
-		(errors?.jsYamlError != null ? 1 : 0) +
+		(errors?.yamlError != null ? 1 : 0) +
 		(errors?.customErrors?.length ?? 0) +
 		(errors?.serverSideError?.error ? 1 : 0);
 
@@ -150,7 +144,7 @@ export default function ValidationErrorConsole({ errors, font }: { errors?: IErr
 								errors.customErrors.map((error: string, index: number) => {
 									return <ErrorMessage key={index} customErrors={error} font={font} />;
 								})}
-							{errors?.jsYamlError?.mark?.line && <ErrorMessage jsYamlError={errors?.jsYamlError} font={font} />}
+							{errors?.yamlError?.linePos?.[0] && <ErrorMessage yamlError={errors?.yamlError} font={font} />}
 						</div>
 					)}
 				</div>
@@ -161,14 +155,14 @@ export default function ValidationErrorConsole({ errors, font }: { errors?: IErr
 
 export function ErrorMessage({
 	ajvError,
-	jsYamlError,
+	yamlError,
 	serverSideError,
 	customErrors,
 	customWarnings,
 	font,
 }: {
 	ajvError?: IAjvError;
-	jsYamlError?: IJsYamlError;
+	yamlError?: YAMLParseError;
 	serverSideError?: IServerSideError;
 	customErrors?: string;
 	customWarnings?: string;
@@ -195,10 +189,10 @@ export function ErrorMessage({
 					<p className="max-w-[100%]">{`${customErrors}`}</p>
 				</div>
 			)}
-			{jsYamlError ? (
+			{yamlError ? (
 				<div className={`${font.className} ${errorsStyle}`}>
-					<p className="max-w-[100%]">{`${jsYamlError.reason} ${
-						jsYamlError.mark && `(Line ${jsYamlError.mark.line})`
+					<p className="max-w-[100%]">{`${yamlError.code} ${
+						yamlError.pos && `(Line ${yamlError.linePos?.[0].line})`
 					}`}</p>
 				</div>
 			) : (

--- a/packages/otelbin/src/components/monaco-editor/ValidationErrorConsole.tsx
+++ b/packages/otelbin/src/components/monaco-editor/ValidationErrorConsole.tsx
@@ -191,9 +191,7 @@ export function ErrorMessage({
 			)}
 			{yamlError ? (
 				<div className={`${font.className} ${errorsStyle}`}>
-					<p className="max-w-[100%]">{`${yamlError.code} ${
-						yamlError.linePos && `(Line ${yamlError.linePos?.[0].line})`
-					}`}</p>
+					<p className="max-w-[100%]">{`${yamlError.message}`}</p>
 				</div>
 			) : (
 				<></>

--- a/packages/otelbin/src/components/monaco-editor/otelCollectorConfigValidation.test.ts
+++ b/packages/otelbin/src/components/monaco-editor/otelCollectorConfigValidation.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./parseYaml";
 import { capitalize, customValidate, findErrorElement } from "./otelCollectorConfigValidation";
 import type { editor } from "monaco-editor";
-import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
+import YAML from "yaml";
 
 const editorBinding = {
 	prefix: "",
@@ -261,12 +261,12 @@ describe("findErrorElement", () => {
 	});
 });
 
-describe("JsYaml.load", () => {
+describe("Yaml.parse", () => {
 	it("should load a YAML document that included numbers and convert it to JSON data with numbers as string", () => {
-		const jsonData = JsYaml.load(yamlData.fallback, { schema: FAILSAFE_SCHEMA });
+		const jsonData = YAML.parse(yamlData.fallback, { schema: "failsafe" });
 		expect(jsonData).toStrictEqual({
-			receivers: { otlp: null, 2222: null },
-			processors: { batch: null, 3333: null },
+			receivers: { otlp: "", 2222: "" },
+			processors: { batch: "", 3333: "" },
 			service: {
 				extensions: ["health_check", "pprof", "zpages", "999"],
 				pipelines: {

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -242,6 +242,8 @@ export function selectConfigType(config: string) {
 	let jsonData: any;
 	try {
 		jsonData = YAML.parse(config, { logLevel: "error", schema: "failsafe" }) as any;
+		// Catching and ignoring errors here since validation errors are already displayed in the validation console.
+		// This prevents additional noise and instability when editing the config.
 	} catch (e) {}
 	if (isK8sConfigMap(jsonData)) {
 		return jsonData.data.relay;

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Dash0 Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Parser } from "yaml";
-import YAML from "yaml";
+import YAML, { Parser } from "yaml";
 export interface SourceToken {
 	type:
 		| "byte-order-mark"

--- a/packages/otelbin/src/components/monaco-editor/parseYaml.ts
+++ b/packages/otelbin/src/components/monaco-editor/parseYaml.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Parser } from "yaml";
-import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
+import YAML from "yaml";
 export interface SourceToken {
 	type:
 		| "byte-order-mark"
@@ -240,8 +240,10 @@ export function isOtelColCRD(jsonData: IOtelColCRD) {
 }
 
 export function selectConfigType(config: string) {
-	const jsonData = JsYaml.load(config, { schema: FAILSAFE_SCHEMA }) as any;
-
+	let jsonData: any;
+	try {
+		jsonData = YAML.parse(config, { logLevel: "error", schema: "failsafe" }) as any;
+	} catch (e) {}
 	if (isK8sConfigMap(jsonData)) {
 		return jsonData.data.relay;
 	} else if (isOtelColCRD(jsonData)) {

--- a/packages/otelbin/src/components/react-flow/ReactFlow.tsx
+++ b/packages/otelbin/src/components/react-flow/ReactFlow.tsx
@@ -5,7 +5,7 @@ import React, { type RefObject, useEffect, useMemo } from "react";
 import ReactFlow, { Background, Panel, useReactFlow, useNodesState, useEdgesState, useStore } from "reactflow";
 import "reactflow/dist/style.css";
 import type { IConfig } from "./dataType";
-import { Parser } from "yaml";
+import YAML, { Parser } from "yaml";
 import useEdgeCreator from "./useEdgeCreator";
 import { useFocus } from "~/contexts/EditorContext";
 import { Minus, Plus, HelpCircle, Lock, Minimize2 } from "lucide-react";
@@ -22,7 +22,6 @@ import ReceiversNode from "./node-types/ReceiversNode";
 import ProcessorsNode from "./node-types/ProcessorsNode";
 import { useLayout } from "./layout/useLayout";
 import CyclicErrorEdge from "./CyclicErrorEdge";
-import JsYaml, { FAILSAFE_SCHEMA } from "js-yaml";
 
 type EditorRefType = RefObject<editor.IStandaloneCodeEditor | null>;
 
@@ -40,7 +39,13 @@ export default function Flow({
 	editorRef: EditorRefType | null;
 }) {
 	const reactFlowInstance = useReactFlow();
-	const jsonData = useMemo(() => JsYaml.load(value, { schema: FAILSAFE_SCHEMA }) as IConfig, [value]);
+
+	const jsonData = useMemo(() => {
+		try {
+			return YAML.parse(value, { logLevel: "error", schema: "failsafe" }) as IConfig;
+		} catch (error: unknown) {}
+	}, [value]) as IConfig;
+
 	const pipelines = useMemo(() => {
 		const parsedYaml = Array.from(new Parser().parse(value));
 		const doc = parsedYaml.find((token) => token.type === "document") as Document;

--- a/packages/otelbin/src/components/react-flow/ReactFlow.tsx
+++ b/packages/otelbin/src/components/react-flow/ReactFlow.tsx
@@ -43,6 +43,8 @@ export default function Flow({
 	const jsonData = useMemo(() => {
 		try {
 			return YAML.parse(value, { logLevel: "error", schema: "failsafe" }) as IConfig;
+			// Catching and ignoring errors here since validation errors are already displayed in the validation console.
+			// This prevents additional noise and instability when editing the config.
 		} catch (error: unknown) {}
 	}, [value]) as IConfig;
 


### PR DESCRIPTION
This pull request addresses the issue of multiple runtime errors generated during YAML config editing, attributed to the JS-yaml library. To enhance the user experience and provide more detailed error information, this PR replaces JS-yaml with the Yaml library. The Yaml library not only eliminates runtime errors but also includes comprehensive error details such as start line, end line, start column, and end column, facilitating better debugging and validation of YAML configurations.

Also, in the Yaml library, there are two options for displaying validation error messages:

1- Short Message:

<img width="387" alt="Screenshot 2024-01-19 at 17 05 47" src="https://github.com/dash0hq/otelbin/assets/76537930/92ed6491-94af-4032-80d8-68d89441461a">
<img width="387" alt="Screenshot 2024-01-19 at 17 06 04" src="https://github.com/dash0hq/otelbin/assets/76537930/1bad93d1-e6e1-47dd-96d0-0b08b34e5e18">
<img width="387" alt="Screenshot 2024-01-19 at 17 07 01" src="https://github.com/dash0hq/otelbin/assets/76537930/1006a3a8-7f74-4b1e-ac9c-76a06df32b16">


2- Long Message:

<img width="387" alt="Screenshot 2024-01-19 at 17 10 27" src="https://github.com/dash0hq/otelbin/assets/76537930/31540451-575e-4ffb-a64a-1377800d2bd1">
<img width="387" alt="Screenshot 2024-01-19 at 17 10 47" src="https://github.com/dash0hq/otelbin/assets/76537930/ae60c6ad-a275-4378-a1f9-1b1feba6a718">
<img width="387" alt="Screenshot 2024-01-19 at 17 11 08" src="https://github.com/dash0hq/otelbin/assets/76537930/a8f324fa-85db-42e5-a616-26fe83bfe3a3">

For this pull request, a short message is implemented, but it can be changed as per the reviewers' request.