### PR TITLE
fix(ui): ensure all supported versions are reachable in dropdown

### DIFF
--- a/packages/otelbin/src/components/validation-type/ValidationTile.tsx
+++ b/packages/otelbin/src/components/validation-type/ValidationTile.tsx
@@ -105,7 +105,7 @@ export default function ValidationTile({
 									/>
 								</SelectTrigger>
 								<SelectContent>
-									<SelectGroup>
+									<SelectGroup style={{ maxHeight: "50vh" }}>
 										{Array.isArray(distribution?.releases) &&
 											distribution?.releases
 												.map((release) => release.version)


### PR DESCRIPTION
Set max height of the version dropdown to 50% of viewport, so that even on small resolutions we can ensure that all versions are reachable through scrolling.

Fixes #310