### PR TITLE
fix: infinite rendering loop

### DIFF
--- a/packages/otelbin/src/components/react-flow/useClientNodes.tsx
+++ b/packages/otelbin/src/components/react-flow/useClientNodes.tsx
@@ -135,7 +135,7 @@ export const calcNodes = (value: IConfig) => {
 	const pipelines = value?.service?.pipelines;
 	const connectors = value?.connectors;
 	if (pipelines == null) {
-		return;
+		return [];
 	}
 
 	const nodesToAdd: Node[] = [];


### PR DESCRIPTION
# Why
The OTelBin UI runs into an infinite rendering loop on syntax errors.

# What
Avoid returning new objects when syntax errors exist and using those as dependencies within hooks.