### PR TITLE
Support for Splunk distro of OpenTelemetry

### DIFF
--- a/.github/workflows/discover-new-releases.yaml
+++ b/.github/workflows/discover-new-releases.yaml
@@ -65,6 +65,63 @@ jobs:
           name: releases-${{ matrix.distro.name }}
           path: .github/workflows/scripts/list-releases/releases.json
 
+  check-splunk-releases:
+    name: Splunk OpenTelemetry Collector
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+        - name: splunk-otel-collector
+          artifact_prefix: splunk-otel-collector
+          artifact_suffix: x86_64.rpm
+    runs-on: ubuntu-latest
+    outputs:
+      releases: ${{ steps.list-releases.outputs.releases }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        env:
+          NODE_MAJOR: 20
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+          sudo apt-get update
+          sudo apt-get install nodejs -y
+      - name: Build list generator
+        working-directory: .github/workflows/scripts/list-releases
+        run: |
+          npm install
+          npm run build
+      - name: Look up ignored releases range
+        id: lookup-ignored-releases
+        shell: bash
+        working-directory: packages/otelbin-validation/src/assets
+        run: |
+          echo "range=$(jq -r '.["${{matrix.distro.name}}"].ignoredReleases' < supported-distributions.json)" | tee -a ${GITHUB_OUTPUT}
+      - name: List matching releases
+        id: list-releases
+        shell: bash
+        env:
+          DISTRO_NAME: ${{ matrix.distro.name }}
+          GH_REPOSITORY: signalfx/splunk-otel-collector
+          GH_ASSET_PREFIX: ${{ matrix.distro.artifact_prefix }}
+          GH_ASSET_SUFFIX: ${{ matrix.distro.artifact_suffix }}
+          IGNORED_RELEASES: ${{ steps.lookup-ignored-releases.outputs.range }}
+        working-directory: .github/workflows/scripts/list-releases
+        run: |
+          npm run start --silent | tee releases.json
+      - name: Upload releases.json artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: releases-${{ matrix.distro.name }}
+          path: .github/workflows/scripts/list-releases/releases.json
+
   check-adot-releases:
     name: AWS Distro for OpenTelemetry
     strategy:
@@ -119,6 +176,7 @@ jobs:
     needs:
     - check-community-releases
     - check-adot-releases
+    - check-splunk-releases
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/packages/otelbin-validation-image/src/index.ts
+++ b/packages/otelbin-validation-image/src/index.ts
@@ -73,6 +73,9 @@ exports.handler = async (event: APIGatewayEvent): Promise<APIGatewayProxyResult>
 		const otelcolRealPath = await realpath("/usr/bin/otelcol");
 
 		switch (distroName) {
+			case "splunk":
+				await exports.validateAdot(otelcolRealPath, configPath, env);
+				break;				
 			case "adot":
 				await exports.validateAdot(otelcolRealPath, configPath, env);
 				break;

--- a/packages/otelbin-validation-image/src/index.ts
+++ b/packages/otelbin-validation-image/src/index.ts
@@ -74,8 +74,6 @@ exports.handler = async (event: APIGatewayEvent): Promise<APIGatewayProxyResult>
 
 		switch (distroName) {
 			case "splunk":
-				await exports.validateAdot(otelcolRealPath, configPath, env);
-				break;				
 			case "adot":
 				await exports.validateAdot(otelcolRealPath, configPath, env);
 				break;

--- a/packages/otelbin-validation/src/assets/supported-distributions.json
+++ b/packages/otelbin-validation/src/assets/supported-distributions.json
@@ -261,5 +261,36 @@
       }
     ],
     "ignoredReleases": "<v0.36.0"
+  },
+  "splunk": {
+    "name": "Splunk OpenTelemetry Collector",
+    "provider": "Splunk Inc.",
+    "description": "Splunk OpenTelemetry Collector",
+    "icon": "splunk",
+    "website": "https://aws.amazon.com/otel",
+    "repository": "signalfx/splunk-otel-collector",
+    "releases": [
+      {
+        "version": "v0.103.0",
+        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.103.0/splunk-otel-collector-0.103.0-1.x86_64.rpm",
+        "released_at": "2024-06-25T18:35:12.000Z"
+      },
+      {
+        "version": "v0.102.0",
+        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.102.0/splunk-otel-collector-0.102.0-1.x86_64.rpm",
+        "released_at": "2024-06-05T18:35:12.000Z"
+      },
+      {
+        "version": "v0.101.0",
+        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.101.0/splunk-otel-collector-0.101.0-1.x86_64.rpm",
+        "released_at": "2024-05-29T18:35:12.000Z"
+      },
+      {
+        "version": "v0.100.0",
+        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.100.0/splunk-otel-collector-0.100.0-1.x86_64.rpm",
+        "released_at": "2024-05-09T18:35:12.000Z"
+      }
+    ],
+    "ignoredReleases": "<v0.100.0"
   }
 }

--- a/packages/otelbin-validation/src/assets/supported-distributions.json
+++ b/packages/otelbin-validation/src/assets/supported-distributions.json
@@ -262,7 +262,7 @@
     ],
     "ignoredReleases": "<v0.36.0"
   },
-  "splunk": {
+  "splunk-otel-collector": {
     "name": "Splunk OpenTelemetry Collector",
     "provider": "Splunk Inc.",
     "description": "Splunk OpenTelemetry Collector",

--- a/packages/otelbin-validation/src/assets/supported-distributions.json
+++ b/packages/otelbin-validation/src/assets/supported-distributions.json
@@ -267,7 +267,7 @@
     "provider": "Splunk Inc.",
     "description": "Splunk OpenTelemetry Collector",
     "icon": "splunk",
-    "website": "https://aws.amazon.com/otel",
+    "website": "https://www.splunk.com/en_us/solutions/opentelemetry.html",
     "repository": "signalfx/splunk-otel-collector",
     "releases": [
       {

--- a/packages/otelbin/src/components/assets/svg/distro-icons/splunk.svg
+++ b/packages/otelbin/src/components/assets/svg/distro-icons/splunk.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="24px" height="24px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <title>splunk</title>
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="invisible_box" data-name="invisible box">
+      <rect width="48" height="48" fill="none"/>
+    </g>
+    <g id="Q3_icons" data-name="Q3 icons">
+      <path d="M37.5,4h-27A6.5,6.5,0,0,0,4,10.5v27A6.5,6.5,0,0,0,10.5,44h27A6.5,6.5,0,0,0,44,37.5v-27A6.5,6.5,0,0,0,37.5,4ZM33.6,26.1c0,.1,0,.2-.2.3L14.7,35.8c-.1.1-.3-.1-.3-.2V30.8c0-.1,0-.2.1-.2l13.6-6.8L14.5,16.9c-.1,0-.1-.1-.1-.2V11.9c0-.1.2-.3.3-.2l18.7,9.4a.5.5,0,0,1,.2.4Z"/>
+    </g>
+  </g>
+</svg>

--- a/packages/otelbin/src/components/validation-type/ValidationTile.tsx
+++ b/packages/otelbin/src/components/validation-type/ValidationTile.tsx
@@ -6,7 +6,9 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectVa
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/tooltip";
 import AdotLogo from "./../assets/svg/distro-icons/adot.svg";
 import OtelLogo from "./../assets/svg/distro-icons/otel.svg";
+import SplunkLogo from "./../assets/svg/distro-icons/splunk.svg";
 import { Github, Globe } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { Button } from "../button";
 import { IconButton } from "../icon-button";
 import { CurrentBadge } from "./ValidationTypeContent";
@@ -47,12 +49,25 @@ export default function ValidationTile({
 		}
 	}
 
+	let Icon: LucideIcon;
+	switch (distribution?.icon) {
+		case "adot":
+			Icon = AdotLogo;
+			break;
+		case "splunk":
+			Icon = SplunkLogo;
+			break;
+		default:
+			Icon = OtelLogo;
+			break;
+	}
+
 	return (
 		<Accordion type="single" collapsible>
 			<AccordionItem value="item-1" className="border-1 border-solid border-neutral-350 rounded-md">
 				<AccordionTrigger className="hover:no-underline px-3 hover:bg-button-hover rounded-md">
 					<div className="flex items-center gap-x-3 w-full">
-						{distribution?.icon === "adot" ? <AdotLogo /> : <OtelLogo />}
+						<Icon />
 						<div className="flex flex-col items-start">
 							<div className="flex items-center gap-x-3">
 								<p className="text-[13px] font-semibold text-neutral-950">{distribution?.name}</p>


### PR DESCRIPTION
Added Splunk OpenTelemetry Collector distribution.

Re-using the ADOT function for validation as `validate` command is not in the distribution. 

Also, only going back 4 releases.