### PR TITLE
Update ignoredReleases to <v0.110.0

### DIFF
--- a/packages/otelbin-validation/src/assets/supported-distributions.json
+++ b/packages/otelbin-validation/src/assets/supported-distributions.json
@@ -143,7 +143,7 @@
         "released_at": "2024-05-06T21:21:47.000Z"
       }
     ],
-    "ignoredReleases": "<v0.105.0"
+    "ignoredReleases": "<v0.110.0"
   },
   "otelcol-contrib": {
     "name": "OpenTelemetry Collector Contrib",
@@ -284,7 +284,7 @@
         "released_at": "2024-05-06T21:24:57.000Z"
       }
     ],
-    "ignoredReleases": "<v0.105.0"
+    "ignoredReleases": "<v0.110.0"
   },
   "adot": {
     "name": "AWS Distro for OpenTelemetry",
@@ -355,7 +355,7 @@
         "released_at": "2024-05-10T18:15:34.000Z"
       }
     ],
-    "ignoredReleases": "<v0.39.0"
+    "ignoredReleases": "<v0.40.0"
   },
   "splunk-otel-collector": {
     "name": "Splunk OpenTelemetry Collector",
@@ -461,6 +461,6 @@
         "released_at": "2024-07-10T21:39:56.000Z"
       }
     ],
-    "ignoredReleases": "<v0.105.0"
+    "ignoredReleases": "<v0.110.0"
   }
 }

--- a/packages/otelbin-validation/src/assets/supported-distributions.json
+++ b/packages/otelbin-validation/src/assets/supported-distributions.json
@@ -76,71 +76,6 @@
         "version": "v0.110.0",
         "artifact": "otelcol_0.110.0_linux_amd64.rpm",
         "released_at": "2024-09-24T14:09:18.000Z"
-      },
-      {
-        "version": "v0.109.0",
-        "artifact": "otelcol_0.109.0_linux_amd64.rpm",
-        "released_at": "2024-09-10T20:16:09.000Z"
-      },
-      {
-        "version": "v0.108.0",
-        "artifact": "otelcol_0.108.0_linux_amd64.rpm",
-        "released_at": "2024-08-27T22:23:48.000Z"
-      },
-      {
-        "version": "v0.107.0",
-        "artifact": "otelcol_0.107.0_linux_amd64.rpm",
-        "released_at": "2024-08-13T16:57:03.000Z"
-      },
-      {
-        "version": "v0.106.1",
-        "artifact": "otelcol_0.106.1_linux_amd64.rpm",
-        "released_at": "2024-07-31T14:17:28.000Z"
-      },
-      {
-        "version": "v0.106.0",
-        "artifact": "otelcol_0.106.0_linux_amd64.rpm",
-        "released_at": "2024-07-30T13:20:04.000Z"
-      },
-      {
-        "version": "v0.105.0",
-        "artifact": "otelcol_0.105.0_linux_amd64.rpm",
-        "released_at": "2024-07-17T03:08:58.000Z"
-      },
-      {
-        "version": "v0.104.0",
-        "artifact": "otelcol_0.104.0_linux_amd64.rpm",
-        "released_at": "2024-07-01T23:57:02.000Z"
-      },
-      {
-        "version": "v0.103.1",
-        "artifact": "otelcol_0.103.1_linux_amd64.rpm",
-        "released_at": "2024-06-24T14:59:53.000Z"
-      },
-      {
-        "version": "v0.103.0",
-        "artifact": "otelcol_0.103.0_linux_amd64.rpm",
-        "released_at": "2024-06-19T15:14:38.000Z"
-      },
-      {
-        "version": "v0.102.1",
-        "artifact": "otelcol_0.102.1_linux_amd64.rpm",
-        "released_at": "2024-06-05T16:03:20.000Z"
-      },
-      {
-        "version": "v0.102.0",
-        "artifact": "otelcol_0.102.0_linux_amd64.rpm",
-        "released_at": "2024-06-04T12:12:08.000Z"
-      },
-      {
-        "version": "v0.101.0",
-        "artifact": "otelcol_0.101.0_linux_amd64.rpm",
-        "released_at": "2024-05-21T20:03:58.000Z"
-      },
-      {
-        "version": "v0.100.0",
-        "artifact": "otelcol_0.100.0_linux_amd64.rpm",
-        "released_at": "2024-05-06T21:21:47.000Z"
       }
     ],
     "ignoredReleases": "<v0.110.0"
@@ -217,71 +152,6 @@
         "version": "v0.110.0",
         "artifact": "otelcol-contrib_0.110.0_linux_amd64.rpm",
         "released_at": "2024-09-24T14:14:17.000Z"
-      },
-      {
-        "version": "v0.109.0",
-        "artifact": "otelcol-contrib_0.109.0_linux_amd64.rpm",
-        "released_at": "2024-09-10T20:20:48.000Z"
-      },
-      {
-        "version": "v0.108.0",
-        "artifact": "otelcol-contrib_0.108.0_linux_amd64.rpm",
-        "released_at": "2024-08-27T22:31:06.000Z"
-      },
-      {
-        "version": "v0.107.0",
-        "artifact": "otelcol-contrib_0.107.0_linux_amd64.rpm",
-        "released_at": "2024-08-13T17:01:48.000Z"
-      },
-      {
-        "version": "v0.106.1",
-        "artifact": "otelcol-contrib_0.106.1_linux_amd64.rpm",
-        "released_at": "2024-07-31T14:20:29.000Z"
-      },
-      {
-        "version": "v0.106.0",
-        "artifact": "otelcol-contrib_0.106.0_linux_amd64.rpm",
-        "released_at": "2024-07-30T13:25:46.000Z"
-      },
-      {
-        "version": "v0.105.0",
-        "artifact": "otelcol-contrib_0.105.0_linux_amd64.rpm",
-        "released_at": "2024-07-16T22:56:07.000Z"
-      },
-      {
-        "version": "v0.104.0",
-        "artifact": "otelcol-contrib_0.104.0_linux_amd64.rpm",
-        "released_at": "2024-07-02T00:03:54.000Z"
-      },
-      {
-        "version": "v0.103.1",
-        "artifact": "otelcol-contrib_0.103.1_linux_amd64.rpm",
-        "released_at": "2024-06-24T15:04:31.000Z"
-      },
-      {
-        "version": "v0.103.0",
-        "artifact": "otelcol-contrib_0.103.0_linux_amd64.rpm",
-        "released_at": "2024-06-19T15:19:39.000Z"
-      },
-      {
-        "version": "v0.102.1",
-        "artifact": "otelcol-contrib_0.102.1_linux_amd64.rpm",
-        "released_at": "2024-06-05T16:06:47.000Z"
-      },
-      {
-        "version": "v0.102.0",
-        "artifact": "otelcol-contrib_0.102.0_linux_amd64.rpm",
-        "released_at": "2024-06-04T12:15:01.000Z"
-      },
-      {
-        "version": "v0.101.0",
-        "artifact": "otelcol-contrib_0.101.0_linux_amd64.rpm",
-        "released_at": "2024-05-21T20:07:16.000Z"
-      },
-      {
-        "version": "v0.100.0",
-        "artifact": "otelcol-contrib_0.100.0_linux_amd64.rpm",
-        "released_at": "2024-05-06T21:24:57.000Z"
       }
     ],
     "ignoredReleases": "<v0.110.0"
@@ -325,34 +195,14 @@
         "released_at": "2024-09-17T23:53:43.000Z"
       },
       {
-        "version": "v0.39.3",
-        "artifact": "https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/v0.39.3/aws-otel-collector.rpm",
-        "released_at": "2024-09-16T22:30:07.000Z"
-      },
-      {
         "version": "v0.40.1",
         "artifact": "https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/v0.40.1/aws-otel-collector.rpm",
         "released_at": "2024-08-28T16:54:02.000Z"
       },
       {
-        "version": "v0.39.2",
-        "artifact": "https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/v0.39.2/aws-otel-collector.rpm",
-        "released_at": "2024-08-23T23:02:43.000Z"
-      },
-      {
         "version": "v0.40.0",
         "artifact": "https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/v0.40.0/aws-otel-collector.rpm",
         "released_at": "2024-06-26T18:35:12.000Z"
-      },
-      {
-        "version": "v0.39.1",
-        "artifact": "https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/v0.39.1/aws-otel-collector.rpm",
-        "released_at": "2024-06-11T16:05:03.000Z"
-      },
-      {
-        "version": "v0.39.0",
-        "artifact": "https://aws-otel-collector.s3.amazonaws.com/amazon_linux/amd64/v0.39.0/aws-otel-collector.rpm",
-        "released_at": "2024-05-10T18:15:34.000Z"
       }
     ],
     "ignoredReleases": "<v0.40.0"
@@ -419,46 +269,6 @@
         "version": "v0.110.0",
         "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.110.0/splunk-otel-collector-0.110.0-1.x86_64.rpm",
         "released_at": "2024-09-27T01:30:28.000Z"
-      },
-      {
-        "version": "v0.109.0",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.109.0/splunk-otel-collector-0.109.0-1.x86_64.rpm",
-        "released_at": "2024-09-17T23:28:41.000Z"
-      },
-      {
-        "version": "v0.108.1",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.108.1/splunk-otel-collector-0.108.1-1.x86_64.rpm",
-        "released_at": "2024-08-30T18:59:30.000Z"
-      },
-      {
-        "version": "v0.108.0",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.108.0/splunk-otel-collector-0.108.0-1.x86_64.rpm",
-        "released_at": "2024-08-28T02:14:10.000Z"
-      },
-      {
-        "version": "v0.107.0",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.107.0/splunk-otel-collector-0.107.0-1.x86_64.rpm",
-        "released_at": "2024-08-21T21:05:55.000Z"
-      },
-      {
-        "version": "v0.106.1",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.106.1/splunk-otel-collector-0.106.1-1.x86_64.rpm",
-        "released_at": "2024-08-08T20:18:44.000Z"
-      },
-      {
-        "version": "v0.106.0",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.106.0/splunk-otel-collector-0.106.0-1.x86_64.rpm",
-        "released_at": "2024-08-07T18:15:45.000Z"
-      },
-      {
-        "version": "v0.105.0",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.105.0/splunk-otel-collector-0.105.0-1.x86_64.rpm",
-        "released_at": "2024-07-30T18:16:59.000Z"
-      },
-      {
-        "version": "v0.104.0",
-        "artifact": "https://github.com/signalfx/splunk-otel-collector/releases/download/v0.104.0/splunk-otel-collector-0.104.0-1.x86_64.rpm",
-        "released_at": "2024-07-10T21:39:56.000Z"
       }
     ],
     "ignoredReleases": "<v0.110.0"


### PR DESCRIPTION
## Root cause

We reached the limit for AWS CDK stacks

```
Error: Number of resources in stack 'otelbin-validation-otelbin-rang-9ffbf': 619 is greater than allowed maximum of 500
```

## Fix

Will remove old versions that are not used anymore. 