### PR TITLE
fix: resolve SIGSEGV for OpenTelemetry Collector distributions

### DIFF
--- a/packages/otelbin-validation/src/main.ts
+++ b/packages/otelbin-validation/src/main.ts
@@ -154,6 +154,7 @@ export class OTelBinValidationStack extends Stack {
           environment: {
             DISTRO_NAME: distributionName,
             DASH0_AUTHORIZATION_TOKEN: props.dash0AuthorizationToken || '',
+            SNOWFLAKE_CRL_ON_DISK_CACHE_DIR: '/tmp', // Remediation for https://github.com/snowflakedb/gosnowflake/pull/1526
           },
           /*
 					 * The default 128 cause the OtelCol process to swap a lot, and that increased


### PR DESCRIPTION
Some versions of the OpenTelemetry Collector upstream distribution are failing with a nil pointer panic/SIGSEGV:

- [Validation tests (otelcol-contrib/v0.133.0)](https://github.com/dash0hq/otelbin/actions/runs/17456429193/job/49572265023#logs)
- [Validation tests (otelcol-contrib/v0.134.1)](https://github.com/dash0hq/otelbin/actions/runs/17456429193/job/49572265019)
- [Validation tests (otelcol-contrib/v0.134.0-nightly.202508310234)](https://github.com/dash0hq/otelbin/actions/runs/17456429193/job/49572265027#logs)
- [Validation tests (otelcol-contrib/v0.135.0-nightly.202509020233)](https://github.com/dash0hq/otelbin/actions/runs/17456429193/job/49572265062#logs)

<details>
<summary>Output of nil pointer panics</summary>

```text
2025-09-04T06:25:33.334Z    bf2a4357-8593-4154-9b56-98819f7b1985    ERROR   Error: /bin/sh -c /usr/bin/otelcol-contrib validate --config=/tmp/config.yaml exited with non-zero code: 2
    at ChildProcess.completionListener (/usr/app/src/index.js:544:107)
    at Object.onceWrapper (node:events:632:26)
    at ChildProcess.emit (node:events:517:28)
    at maybeClose (node:internal/child_process:1098:16)
    at ChildProcess._handle.onexit (node:internal/child_process:303:5)
    at Process.callbackTrampoline (node:internal/async_hooks:128:17)
    ...
    at spawnAsync2 (/usr/app/src/index.js:512:25)
    at exports.validateOtelCol (/usr/app/src/index.js:3574:9)
    at exports.handler (/usr/app/src/index.js:3490:23) {
  pid: 224,
  output: [
    '',
    'panic: runtime error: invalid memory address or nil pointer dereference\n' +
      '[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x55dc5e]\n' +
      '\n' +
      'goroutine 1 [running]:\n' +
      'regexp.(*Regexp).ReplaceAllString(0x0, {0xc000d70ad0, 0xd}, {0xc33eccf, 0xa})\n' +
      '\tregexp/regexp.go:575 +0x5e\n' +
      'github.com/snowflakedb/gosnowflake.maskClientSecret(...)\n' +
      '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/secret_detector.go:56\n' +
      'github.com/snowflakedb/gosnowflake.maskSecrets({0xc000d70ad0?, 0xc00119f988?})\n' +
      '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/secret_detector.go:67 +0x39\n' +
      'github.com/snowflakedb/gosnowflake.(*sfTextFormatter).Format(0xc000a735c0, 0xc000b3ae00)\n' +
      '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/log.go:71 +0x25\n' +
      'github.com/sirupsen/logrus.(*Entry).write(0xc000b3ae00)\n' +
      '\tgithub.com/sirupsen/logrus@v1.9.3/entry.go:289 +0x95\n' +
      'github.com/sirupsen/logrus.(*Entry).log(0xc000b3ad90, 0x4, {0xc000d70ad0, 0xd})\n' +
      '\tgithub.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x425\n' +
      'github.com/sirupsen/logrus.(*Entry).Log(0xc000b3ad90, 0x4, {0xc001137980?, 0xc0011266b8?, 0x10?})\n' +
      '\tgithub.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x48\n' +
      'github.com/sirupsen/logrus.(*Logger).Log(0xc000ba2b80, 0x4, {0xc001137980, 0x1, 0x1})\n' +
      '\tgithub.com/sirupsen/logrus@v1.9.3/logger.go:204 +0x58\n' +
      'github.com/sirupsen/logrus.(*Logger).Info(...)\n' +
      '\tgithub.com/sirupsen/logrus@v1.9.3/logger.go:226\n' +
      'github.com/snowflakedb/gosnowflake.(*defaultLogger).Info(0xc0011266a0, {0xc001137980, 0x1, 0x1})\n' +
      '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/log.go:254 +0x4c\n' +
      'github.com/snowflakedb/gosnowflake.defaultCrlOnDiskCacheDir()\n' +
      '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/crl.go:609 +0x7f\n' +
      'github.com/snowflakedb/gosnowflake.newCrlCacheCleaner()\n' +
      '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/crl.go:96 +0x1f3\n' +
      'github.com/snowflakedb/gosnowflake.init()\n' +
      '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/crl.go:57 +0x56e\n'
  ],
  stdout: '',
  stderr: 'panic: runtime error: invalid memory address or nil pointer dereference\n' +
    '[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x55dc5e]\n' +
    '\n' +
    'goroutine 1 [running]:\n' +
    'regexp.(*Regexp).ReplaceAllString(0x0, {0xc000d70ad0, 0xd}, {0xc33eccf, 0xa})\n' +
    '\tregexp/regexp.go:575 +0x5e\n' +
    'github.com/snowflakedb/gosnowflake.maskClientSecret(...)\n' +
    '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/secret_detector.go:56\n' +
    'github.com/snowflakedb/gosnowflake.maskSecrets({0xc000d70ad0?, 0xc00119f988?})\n' +
    '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/secret_detector.go:67 +0x39\n' +
    'github.com/snowflakedb/gosnowflake.(*sfTextFormatter).Format(0xc000a735c0, 0xc000b3ae00)\n' +
    '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/log.go:71 +0x25\n' +
    'github.com/sirupsen/logrus.(*Entry).write(0xc000b3ae00)\n' +
    '\tgithub.com/sirupsen/logrus@v1.9.3/entry.go:289 +0x95\n' +
    'github.com/sirupsen/logrus.(*Entry).log(0xc000b3ad90, 0x4, {0xc000d70ad0, 0xd})\n' +
    '\tgithub.com/sirupsen/logrus@v1.9.3/entry.go:252 +0x425\n' +
    'github.com/sirupsen/logrus.(*Entry).Log(0xc000b3ad90, 0x4, {0xc001137980?, 0xc0011266b8?, 0x10?})\n' +
    '\tgithub.com/sirupsen/logrus@v1.9.3/entry.go:304 +0x48\n' +
    'github.com/sirupsen/logrus.(*Logger).Log(0xc000ba2b80, 0x4, {0xc001137980, 0x1, 0x1})\n' +
    '\tgithub.com/sirupsen/logrus@v1.9.3/logger.go:204 +0x58\n' +
    'github.com/sirupsen/logrus.(*Logger).Info(...)\n' +
    '\tgithub.com/sirupsen/logrus@v1.9.3/logger.go:226\n' +
    'github.com/snowflakedb/gosnowflake.(*defaultLogger).Info(0xc0011266a0, {0xc001137980, 0x1, 0x1})\n' +
    '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/log.go:254 +0x4c\n' +
    'github.com/snowflakedb/gosnowflake.defaultCrlOnDiskCacheDir()\n' +
    '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/crl.go:609 +0x7f\n' +
    'github.com/snowflakedb/gosnowflake.newCrlCacheCleaner()\n' +
    '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/crl.go:96 +0x1f3\n' +
    'github.com/snowflakedb/gosnowflake.init()\n' +
    '\tgithub.com/snowflakedb/gosnowflake@v1.16.0/crl.go:57 +0x56e\n',
  status: 2,
  signal: null
}
```
</details>

This is due to a bug in [github.com/snowflakedb/gosnowflake v1.16.0](https://docs.snowflake.com/en/release-notes/clients-drivers/golang-2025#version-1-16-0-august-14-2025) which was added to OpenTelemetry Collector Contrib in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42099 (part of [v0.133.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.133.0) and [v0.134.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.134.0)).

Setting the environment variable `SNOWFLAKE_CRL_ON_DISK_CACHE_DIR` to an existing directory (`/tmp`) works around the issue for now.

Refs https://github.com/snowflakedb/gosnowflake/issues/1533