### PR TITLE
fix(splunk): install util-linux for /sbin/nologin binary

### DIFF
--- a/packages/otelbin-validation-image/Dockerfile
+++ b/packages/otelbin-validation-image/Dockerfile
@@ -33,7 +33,7 @@ RUN apk --no-cache add unzip && unzip /tmp/opentelemetry-collector-layer-${TARGE
 FROM public.ecr.aws/lambda/nodejs:22
 
 # Install useradd command needed by the otelcontrib RPM and xargs
-RUN microdnf -y install findutils shadow-utils ; microdnf clean all
+RUN microdnf -y install findutils shadow-utils util-linux; microdnf clean all
 
 COPY --from=downloader /tmp/otelcol.rpm /tmp/otelcol.rpm
 COPY --from=builder-extension /tmp/extensions /opt/extensions


### PR DESCRIPTION
Error message while installing Splunk OTel Collector:

```text
useradd: invalid shell 'splunk-otel-collector'
warning: user splunk-otel-collector does not exist - using root
warning: group splunk-otel-collector does not exist - using root
chown: invalid user: 'splunk-otel-collector:splunk-otel-collector'
```

https://github.com/signalfx/splunk-otel-collector/blob/v0.138.0/packaging/fpm/preinstall.sh#L17-L18