### PR TITLE
ci: configure NPM projects in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     directories:
       - "/packages/otelbin"
       - "/packages/otelbin-validation"
-      - "packages/otelbin-validation-image"
+      - "/packages/otelbin-validation-image"
     schedule:
       interval: "monthly"
     pull-request-branch-name:


### PR DESCRIPTION
Updated the dependabot configuration to include multiple directories for npm updates and removed the specific day for the update schedule (which doesn't work with a monthly interval).