### PR TITLE
fix: prevent shell injection in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,14 +14,16 @@ jobs:
     steps:
       - name: Resolve ref to SHA
         id: resolve
+        env:
+          INPUT_REF: ${{ inputs.ref }}
         run: |
-          sha=$(git ls-remote "${{ github.server_url }}/${{ github.repository }}" "${{ inputs.ref }}" | head -1 | cut -f1)
+          sha=$(git ls-remote "${{ github.server_url }}/${{ github.repository }}" "${INPUT_REF}" | head -1 | cut -f1)
           if [ -z "${sha}" ]; then
             # Try as a raw SHA
-            sha="${{ inputs.ref }}"
+            sha="${INPUT_REF}"
           fi
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
-          echo "Resolved ref '${{ inputs.ref }}' to SHA ${sha}"
+          echo "Resolved ref '${INPUT_REF}' to SHA ${sha}"
 
       - name: Create Vercel production deployment and wait for completion
         env:


### PR DESCRIPTION
## Summary
- Fixes template injection vulnerability in `.github/workflows/deploy.yaml` (flagged by Aikido SAST)
- `${{ inputs.ref }}` was directly interpolated into a shell `run:` block, allowing potential command injection
- Now passes the input through an `env` variable (`INPUT_REF`), matching the safe pattern already used in step 2

## Risk assessment
- **Practical risk was low** — `workflow_dispatch` can only be triggered by users with write access
- **Fix is defense-in-depth** — follows GitHub's recommended practice of never interpolating user-controlled values directly into `run:` blocks

## Test plan
- [x] Aikido re-scan confirms zero findings on the fixed file
- [ ] Verify deploy workflow still works correctly when triggered manually