### PR TITLE
ci: use different GH token for create-pull-request action

### DIFF
--- a/.github/workflows/discover-new-releases.yaml
+++ b/.github/workflows/discover-new-releases.yaml
@@ -219,6 +219,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
+          token: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
           title: Update supported versions
           commit-message: 'chore: update the version list of supported OpenTelemetry collector distros'
           add-paths: packages/otelbin-validation/src/assets/supported-distributions.json


### PR DESCRIPTION
CLA and OTelBin tests checks aren't executed because using the automatically created GitHub token for GitHub Actions workflow runs doesn't trigger them, so we always have to add a dummy commit to actually trigger them.

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run.Source

https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow