### PR TITLE
ci: pass GITHUB_TOKEN to list-releases script to avoid rate limiting

### DIFF
--- a/.github/workflows/discover-new-releases.yaml
+++ b/.github/workflows/discover-new-releases.yaml
@@ -59,6 +59,7 @@ jobs:
           GH_ASSET_PREFIX: ${{ matrix.distro.artifact_prefix }}
           GH_ASSET_SUFFIX: ${{ matrix.distro.artifact_suffix }}
           IGNORED_RELEASES: ${{ steps.lookup-ignored-releases.outputs.range }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .github/workflows/scripts/list-releases
         run: |
           npm run start --silent | tee releases.json
@@ -119,6 +120,7 @@ jobs:
           GH_ASSET_PREFIX: ${{ matrix.distro.artifact_prefix }}
           GH_ASSET_SUFFIX: ${{ matrix.distro.artifact_suffix }}
           IGNORED_RELEASES: ${{ steps.lookup-ignored-releases.outputs.range }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: .github/workflows/scripts/list-releases
         run: |
           npm run start --silent | tee releases.json
@@ -169,6 +171,7 @@ jobs:
           DISTRO_NAME: adot
           GH_REPOSITORY: aws-observability/aws-otel-collector
           IGNORED_RELEASES: ${{ steps.lookup-ignored-releases.outputs.range }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run start --silent | tee releases.json
       - name: Upload releases.json artifact

--- a/.github/workflows/scripts/list-releases/src/index.ts
+++ b/.github/workflows/scripts/list-releases/src/index.ts
@@ -22,6 +22,7 @@ declare global {
 			GH_ASSET_PREFIX?: string;
 			GH_ASSET_SUFFIX?: string;
 			IGNORED_RELEASES: string;
+			GITHUB_TOKEN?: string;
 		}
 	}
 }
@@ -31,7 +32,7 @@ const [owner, repo] = process.env.GH_REPOSITORY.split("/");
 const ignoredReleases = process.env.IGNORED_RELEASES;
 
 (async () => {
-	const octokit = new Octokit();
+	const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 	const iterator = octokit.paginate.iterator(octokit.rest.repos.listReleases, {
 		owner,
 		repo,


### PR DESCRIPTION
## Summary

- Passes `secrets.GITHUB_TOKEN` to all three "List matching releases" steps in `discover-new-releases.yaml`
- Accepts `GITHUB_TOKEN` as an optional env var in `index.ts` and passes it to the `Octokit` constructor

This increases the GitHub API rate limit from 60 to 5,000 requests/hour for authenticated calls, preventing failures in the release discovery workflow.

This will resolve running into the rate limit in some jobs, for example:
https://github.com/dash0hq/otelbin/actions/runs/24323684130/job/71014586395#step:6:15

## Test plan

- [ ] Trigger `discover-new-releases` workflow manually via `workflow_dispatch` and verify it completes without rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)