### PR TITLE
Revert "ci: use different GH token for create-pull-request action"

### DIFF
--- a/.github/workflows/discover-new-releases.yaml
+++ b/.github/workflows/discover-new-releases.yaml
@@ -219,7 +219,6 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
-          token: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
           title: Update supported versions
           commit-message: 'chore: update the version list of supported OpenTelemetry collector distros'
           add-paths: packages/otelbin-validation/src/assets/supported-distributions.json


### PR DESCRIPTION
The `REPOSITORY_FULL_ACCESS_GITHUB_TOKEN` token is apparently lacking access to this repository. 😞 

Refs #584

This reverts commit b35f0f4f1b1206dbbeac2e07f7a09a1b049e1b43.