### PR TITLE
build(deps): bump @clerk/* in /packages/otelbin

### DIFF
--- a/packages/otelbin/package-lock.json
+++ b/packages/otelbin/package-lock.json
@@ -1917,13 +1917,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@clerk/backend": {
-			"version": "2.33.2",
-			"resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.2.tgz",
-			"integrity": "sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw==",
+			"version": "2.33.3",
+			"resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.3.tgz",
+			"integrity": "sha512-cgkFVEYFG2nZn4QDuYBhiAwPtMdo8Yj7DAtq/SBQ5C/ainh3uxNRDgUj4bFn52qJkWLiCkraYJIw1b8dEUbUBg==",
 			"license": "MIT",
 			"dependencies": {
-				"@clerk/shared": "^3.47.4",
-				"@clerk/types": "^4.101.22",
+				"@clerk/shared": "^3.47.5",
+				"@clerk/types": "^4.101.23",
 				"standardwebhooks": "^1.0.0",
 				"tslib": "2.8.1"
 			},
@@ -1971,9 +1971,9 @@
 			}
 		},
 		"node_modules/@clerk/shared": {
-			"version": "3.47.4",
-			"resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.4.tgz",
-			"integrity": "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==",
+			"version": "3.47.5",
+			"resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.5.tgz",
+			"integrity": "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2027,12 +2027,12 @@
 			}
 		},
 		"node_modules/@clerk/types": {
-			"version": "4.101.22",
-			"resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.22.tgz",
-			"integrity": "sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA==",
+			"version": "4.101.23",
+			"resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.23.tgz",
+			"integrity": "sha512-t5ypYYDkT5TPaNIDjLnYk9GpkJgwNTBiS7h6FuUTjoySQtf7amNDS1A1eOu7NOcVpqiSeKg+0wzGxxcre00kMA==",
 			"license": "MIT",
 			"dependencies": {
-				"@clerk/shared": "^3.47.4"
+				"@clerk/shared": "^3.47.5"
 			},
 			"engines": {
 				"node": ">=18.17.0"

--- a/packages/otelbin/package-lock.json
+++ b/packages/otelbin/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@clerk/nextjs": "^6.39.2",
+				"@clerk/nextjs": "^6.39.3",
 				"@clerk/themes": "^2.2.31",
 				"@dagrejs/dagre": "^1.0.4",
 				"@dash0hq/sdk-web": "^0.6.1",
@@ -1932,12 +1932,12 @@
 			}
 		},
 		"node_modules/@clerk/clerk-react": {
-			"version": "5.61.5",
-			"resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.5.tgz",
-			"integrity": "sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg==",
+			"version": "5.61.6",
+			"resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.6.tgz",
+			"integrity": "sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@clerk/shared": "^3.47.4",
+				"@clerk/shared": "^3.47.5",
 				"tslib": "2.8.1"
 			},
 			"engines": {
@@ -1949,15 +1949,15 @@
 			}
 		},
 		"node_modules/@clerk/nextjs": {
-			"version": "6.39.2",
-			"resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.2.tgz",
-			"integrity": "sha512-NTAgvhpntCdQD4KR+4f/KFs8cqd6oyzoE73AoO9w0xKoJbTB8IIIPG+CtdIw+mx7z4JqbQATKWZbMPGeZbZYCw==",
+			"version": "6.39.3",
+			"resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.3.tgz",
+			"integrity": "sha512-a64lJ1IlV1uA7eEe8DOx+v2bkNOhnTsNlB5THP/xkHvynHqZhc74Yt05sm1vTniWwhJpJspAZ95pCWUX/RVZ2Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@clerk/backend": "^2.33.2",
-				"@clerk/clerk-react": "^5.61.5",
-				"@clerk/shared": "^3.47.4",
-				"@clerk/types": "^4.101.22",
+				"@clerk/backend": "^2.33.3",
+				"@clerk/clerk-react": "^5.61.6",
+				"@clerk/shared": "^3.47.5",
+				"@clerk/types": "^4.101.23",
 				"server-only": "0.0.1",
 				"tslib": "2.8.1"
 			},

--- a/packages/otelbin/package.json
+++ b/packages/otelbin/package.json
@@ -18,7 +18,7 @@
 		"licenses": "npx license-report --output=csv --fields=name --fields=installedVersion --fields=licenseType > licenses.csv"
 	},
 	"dependencies": {
-		"@clerk/nextjs": "^6.39.2",
+		"@clerk/nextjs": "^6.39.3",
 		"@clerk/themes": "^2.2.31",
 		"@dagrejs/dagre": "^1.0.4",
 		"@dash0hq/sdk-web": "^0.6.1",


### PR DESCRIPTION
- build(deps): bump @clerk/backend from 2.33.2 to 2.33.3 in /packages/otelbin
- build(deps): bump @clerk/shared from 3.47.4 to 3.47.5 in /packages/otelbin
- build(deps): bump @clerk/nextjs from 6.39.2 to 6.39.3 in /packages/otelbin
- build(deps): bump @clerk/clerk-react from 5.61.5 to 5.61.6 in /packages/otelbin

Closes https://github.com/dash0hq/otelbin/pull/596
Closes https://github.com/dash0hq/otelbin/pull/597
Closes https://github.com/dash0hq/otelbin/pull/598
Closes https://github.com/dash0hq/otelbin/pull/599