### PR TITLE
ci: make validation stack teardown rate-limit-aware

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,11 @@ permissions:
   contents: read
 
 # Ensure we only have one such workflow running per branch, to avoid
-# conflicts in the test env
+# conflicts in the test env. `clean-up-test-env.yaml` uses the same
+# group key so a CI deploy and a teardown for the same PR are serialized.
 concurrency:
   group: ${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   otelbin-verify:

--- a/.github/workflows/clean-up-test-env.yaml
+++ b/.github/workflows/clean-up-test-env.yaml
@@ -6,11 +6,21 @@ on:
     types: [ closed ]
   workflow_dispatch:
 
+# Use the same group key as `ci.yaml` so a CI deploy and this teardown for
+# the same PR are serialized, and so two teardowns for the same PR (e.g.
+# closed -> reopened -> closed, or a PR close racing a manual dispatch)
+# cannot both hit the same CloudFormation stack at once.
+# `cancel-in-progress: false` so a queued run waits for the in-flight one
+# rather than killing the destroy mid-retry-loop.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   cleanup_test_env:
     name: Clean up test environment ${{ github.ref }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -77,7 +87,6 @@ jobs:
 
       - name: Delete validation backend
         shell: bash
-        working-directory: packages/otelbin-validation
         env:
           AWS_ROLE_ARN: ${{ steps.select_credentials.outputs.role_arn }}
           AWS_DEFAULT_REGION: 'us-east-2'
@@ -86,4 +95,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TEST_ENVIRONMENT_NAME: ${{ steps.get_test_env_name.outputs.test_env_name }}
         run: |
-          npx projen destroy --force
+          ./.github/workflows/scripts/destroy-validation-stack.sh

--- a/.github/workflows/scripts/destroy-validation-stack.sh
+++ b/.github/workflows/scripts/destroy-validation-stack.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Tear down the validation backend CDK stack with rate-limit-aware retries.
+#
+# CloudFormation can hit Lambda `Rate exceeded` errors when deleting the many
+# per-distro Lambda functions in parallel, leaving the stack in DELETE_FAILED.
+# CDK refuses to continue from that state, so on failure we fall back to
+# `aws cloudformation delete-stack` directly -- CloudFormation retries only
+# the failed resources, and by then the Lambda rate-limit window has cleared.
+#
+# Required env vars: TEST_ENVIRONMENT_NAME (plus AWS_* / CDK_* for the tools).
+# Run from the repo root.
+
+set -uo pipefail
+
+: "${TEST_ENVIRONMENT_NAME:?TEST_ENVIRONMENT_NAME must be set}"
+
+ROOT_STACK="otelbin-validation-${TEST_ENVIRONMENT_NAME}"
+
+if (cd packages/otelbin-validation && npx projen destroy --force); then
+    echo "cdk destroy succeeded."
+    exit 0
+fi
+echo "cdk destroy failed; falling back to direct CloudFormation deletion of ${ROOT_STACK}."
+
+stack_exists() {
+    aws cloudformation describe-stacks --stack-name "${ROOT_STACK}" >/dev/null 2>&1
+}
+
+for attempt in 1 2 3; do
+    if ! stack_exists; then
+        echo "Stack ${ROOT_STACK} deleted before attempt ${attempt}."
+        exit 0
+    fi
+
+    echo "Attempt ${attempt}: re-issuing delete-stack for ${ROOT_STACK}."
+    aws cloudformation delete-stack --stack-name "${ROOT_STACK}"
+
+    if aws cloudformation wait stack-delete-complete --stack-name "${ROOT_STACK}"; then
+        echo "Stack ${ROOT_STACK} deleted on attempt ${attempt}."
+        exit 0
+    fi
+
+    echo "Stack ${ROOT_STACK} did not reach DELETE_COMPLETE on attempt ${attempt}."
+    backoff=$((60 * attempt))
+    echo "Backing off ${backoff}s before retrying."
+    sleep "${backoff}"
+done
+
+echo "Failed to delete ${ROOT_STACK} after 3 attempts -- manual cleanup required."
+aws cloudformation describe-stack-events --stack-name "${ROOT_STACK}" \
+    --no-paginate --query 'StackEvents[:20]' --output table || true
+exit 1


### PR DESCRIPTION
CloudFormation hits Lambda `Rate exceeded` errors when deleting the many per-distro Lambda functions in parallel, leaving the validation stack in `DELETE_FAILED`. CDK refuses to continue from that state, so the clean-up workflow has been failing and requiring manual re-runs.

On `cdk destroy` failure, fall back to calling `aws cloudformation delete-stack` directly with up to three retries and exponential backoff. CloudFormation then retries only the failed resources, and by then the Lambda rate-limit window has typically cleared.

Also add a `concurrency` group keyed on `github.ref` (shared with `ci.yaml`) so a CI deploy and a teardown for the same PR -- or two teardowns racing on the same PR -- are serialized rather than hitting the same stack at once. Bump `timeout-minutes` to 60 to leave headroom for the retry loop on top of the `aws cloudformation wait` poll budget.