### PR TITLE
ci: ensure the test env name is only lowercase alphanumeric characters

### DIFF
--- a/.github/workflows/scripts/test_env_name.sh
+++ b/.github/workflows/scripts/test_env_name.sh
@@ -7,12 +7,8 @@ if [[ ${#REF_NAME} -gt 12 ]]; then
     REF_NAME="${REF_NAME:0:12}-$(echo "${REF_NAME:12}" | md5sum | awk '{print $1}' | tr '_' '-' | cut -c 1-5 | tr -d '\n')"
 fi
 
-# Check if REF_NAME starts with "dependabot/" and if so, replace "dependabot/" with "dependabot-"
+# Make result lowercase and replace all non-alphanumeric characters with a dash (-).
 # This should fix the following error:
 #   Error: Invalid S3 bucket name (value: supported-distributions-list-dependabot/n-059e9)
 #   Bucket name must only contain lowercase characters and the symbols, period (.) and dash (-) (offset: 39)
-if [[ "${REF_NAME}" == dependabot/* ]]; then
-    REF_NAME="${REF_NAME/dependabot\//dependabot-}"
-fi
-
-echo "${REF_NAME}"
+echo "${REF_NAME}" | tr -d '[:cntrl:]' | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-'


### PR DESCRIPTION
Example:
```
# REF_NAME=foo/BAR_123 .github/workflows/scripts/test_env_name.sh
foo-bar-123
```