### PR TITLE
chore(deps): upgrade next to 16.2.11

### DIFF
--- a/packages/otelbin/package-lock.json
+++ b/packages/otelbin/package-lock.json
@@ -40,7 +40,7 @@
 				"monaco-editor": "^0.44.0",
 				"monaco-languageserver-types": "^0.2.3",
 				"monaco-yaml": "^5.1.1",
-				"next": "^16.2.6",
+				"next": "^16.2.11",
 				"projen": "^0.77.1",
 				"react": "^19.2.3",
 				"react-dom": "^19.2.3",
@@ -3685,9 +3685,9 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-			"integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
+			"integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
@@ -3731,9 +3731,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-			"integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
+			"integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3747,9 +3747,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-			"integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
+			"integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
 			"cpu": [
 				"x64"
 			],
@@ -3763,11 +3763,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-			"integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
+			"integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3779,11 +3782,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-			"integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
+			"integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3795,11 +3801,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-			"integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
+			"integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3811,11 +3820,14 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-			"integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
+			"integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -3827,9 +3839,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-			"integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
+			"integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
 			"cpu": [
 				"arm64"
 			],
@@ -3843,9 +3855,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-			"integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
+			"integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
 			"cpu": [
 				"x64"
 			],
@@ -11926,12 +11938,12 @@
 			"license": "MIT"
 		},
 		"node_modules/next": {
-			"version": "16.2.6",
-			"resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-			"integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+			"version": "16.2.11",
+			"resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
+			"integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "16.2.6",
+				"@next/env": "16.2.11",
 				"@swc/helpers": "0.5.15",
 				"baseline-browser-mapping": "^2.9.19",
 				"caniuse-lite": "^1.0.30001579",
@@ -11945,14 +11957,14 @@
 				"node": ">=20.9.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "16.2.6",
-				"@next/swc-darwin-x64": "16.2.6",
-				"@next/swc-linux-arm64-gnu": "16.2.6",
-				"@next/swc-linux-arm64-musl": "16.2.6",
-				"@next/swc-linux-x64-gnu": "16.2.6",
-				"@next/swc-linux-x64-musl": "16.2.6",
-				"@next/swc-win32-arm64-msvc": "16.2.6",
-				"@next/swc-win32-x64-msvc": "16.2.6",
+				"@next/swc-darwin-arm64": "16.2.11",
+				"@next/swc-darwin-x64": "16.2.11",
+				"@next/swc-linux-arm64-gnu": "16.2.11",
+				"@next/swc-linux-arm64-musl": "16.2.11",
+				"@next/swc-linux-x64-gnu": "16.2.11",
+				"@next/swc-linux-x64-musl": "16.2.11",
+				"@next/swc-win32-arm64-msvc": "16.2.11",
+				"@next/swc-win32-x64-msvc": "16.2.11",
 				"sharp": "^0.34.5"
 			},
 			"peerDependencies": {

--- a/packages/otelbin/package.json
+++ b/packages/otelbin/package.json
@@ -49,7 +49,7 @@
 		"monaco-editor": "^0.44.0",
 		"monaco-languageserver-types": "^0.2.3",
 		"monaco-yaml": "^5.1.1",
-		"next": "^16.2.6",
+		"next": "^16.2.11",
 		"projen": "^0.77.1",
 		"react": "^19.2.3",
 		"react-dom": "^19.2.3",


### PR DESCRIPTION
## Summary
Upgrades `next` to `16.2.11` in `packages/otelbin`, a patch bump within the 16.2.x line that pulls in upstream security fixes (8 high, 9 medium, 1 low severity advisories).
## Changes
- `packages/otelbin/package.json`: `next` → `16.2.11`
- `packages/otelbin/package-lock.json`: refreshed
## Notes
- Patch-level, API-compatible bump; no source changes required.