### PR TITLE
fix(ci): unblock dependabot PRs and stop leaking the Dash0 token into cdk.out

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,15 @@ on:
   pull_request:
     branches:
       - 'main'
+  # Dependabot PRs are excluded from repo secrets under the `pull_request` event, so the
+  # credentialed jobs below (prep-itests, run-itests) additionally run under
+  # `pull_request_target`, which is only actually used for the `dependabot[bot]` actor (see the
+  # `if:` conditions on those jobs). `pull_request_target` runs with the workflow file from
+  # `main`, not from the PR branch, so a dependency-bump PR can't rewrite the CI steps it runs
+  # under with elevated credentials.
+  pull_request_target:
+    branches:
+      - 'main'
 
 permissions:
   id-token: write
@@ -17,8 +26,12 @@ permissions:
 # Ensure we only have one such workflow running per branch, to avoid
 # conflicts in the test env. `clean-up-test-env.yaml` uses the same
 # group key so a CI deploy and a teardown for the same PR are serialized.
+# `github.head_ref` (the PR branch name) is used instead of `github.ref` so that
+# `pull_request` and `pull_request_target` runs for the same PR share a group; `pull_request_target`
+# reports `github.ref` as the base branch (`refs/heads/main`), which would otherwise put every
+# open PR's privileged run into the same group as every other PR and as `push` runs on main.
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -26,6 +39,9 @@ jobs:
     name: OTelBin tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Skip the redundant pull_request_target run for everyone except dependabot: non-dependabot
+    # PRs already ran this under the plain pull_request event above.
+    if: github.event_name != 'pull_request_target' || github.actor == 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -56,6 +72,8 @@ jobs:
     name: OTelBin Validation Image Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # See otelbin-verify above for why this condition exists.
+    if: github.event_name != 'pull_request_target' || github.actor == 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -81,6 +99,8 @@ jobs:
     name: OTelBin Validation Stack Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # See otelbin-verify above for why this condition exists.
+    if: github.event_name != 'pull_request_target' || github.actor == 'dependabot[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -112,6 +132,13 @@ jobs:
     needs: ['otelbin-verify', 'otelbin-validation-image-verify', 'otelbin-validation-verify']
     runs-on: 8core_32gb
     timeout-minutes: 30
+    # Runs for: pushes to main; PRs from non-dependabot actors (via pull_request, which already
+    # has secrets for same-repo branches); and dependabot PRs (via pull_request_target only,
+    # since pull_request never carries secrets for the dependabot[bot] actor).
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
     outputs:
       test_matrix: ${{ steps.prepare_test_matrix.outputs.test_matrix }}
       validation_api_apigateway_name: ${{ steps.parse_cdk_output.outputs.api_gateway_name }}
@@ -122,6 +149,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # For pull_request_target, default checkout is the base branch (main); we need the
+          # PR's own head commit, which is what's actually being tested/deployed.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -132,8 +162,11 @@ jobs:
       - name: Install CDK dependencies
         shell: bash
         working-directory: packages/otelbin-validation
+        # --ignore-scripts: this job configures AWS credentials in a later step; skipping
+        # install-time scripts prevents a compromised/malicious dependency from planting
+        # something in this job that later reads those credentials from the shared runner env.
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm i -g aws-cli
 
       - name: Get test environment name
@@ -218,6 +251,12 @@ jobs:
   run-itests:
     name: Validation tests
     needs: ['prep-itests']
+    # See prep-itests above for why this condition exists; run-itests needs the same gating
+    # since it depends on prep-itests's outputs and shares the same credential requirements.
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
     strategy:
       matrix:
         test_matrix: ${{ fromJson(needs.prep-itests.outputs.test_matrix )}}
@@ -228,6 +267,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # See prep-itests above: check out the PR's own head commit, not the base branch.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -238,8 +279,9 @@ jobs:
       - name: Install CDK dependencies
         shell: bash
         working-directory: packages/otelbin-validation
+        # See prep-itests above for why --ignore-scripts is used here.
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: Select credentials
         id: select_credentials

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,7 +226,10 @@ jobs:
           CDK_DEPLOY_REGION: 'us-east-2'
           GH_TOKEN: ${{ github.token }}
           TEST_ENVIRONMENT_NAME: ${{ steps.get_test_env_name.outputs.test_env_name }}
-          DASH0_AUTHORIZATION_TOKEN: ${{ secrets.DASH0_AUTHORIZATION_TOKEN }}
+        # The Dash0 authorization token is no longer passed in here: the Lambda's environment
+        # variable is populated by CloudFormation from Secrets Manager at deploy time (see
+        # DASH0_AUTHORIZATION_TOKEN_SECRET_NAME in src/main.ts), so it never has to pass through
+        # this workflow (or any GitHub secret) at all.
         run: |
           npx projen deploy --require-approval never --outputs-file ./cdk-outputs.json
 

--- a/packages/otelbin-validation/src/main.ts
+++ b/packages/otelbin-validation/src/main.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
-import { App, CfnOutput, CustomResource, Duration, NestedStack, NestedStackProps, RemovalPolicy, Stack, StackProps, Tags } from 'aws-cdk-lib';
+import { App, CfnOutput, CustomResource, Duration, NestedStack, NestedStackProps, RemovalPolicy, SecretValue, Stack, StackProps, Tags } from 'aws-cdk-lib';
 import { ApiKeySourceType, AwsIntegration, IResource, LambdaIntegration, RestApi, UsagePlan } from 'aws-cdk-lib/aws-apigateway';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { ManagedPolicy, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
@@ -9,6 +9,12 @@ import { BlockPublicAccess, Bucket } from 'aws-cdk-lib/aws-s3';
 import { BucketDeployment, Source } from 'aws-cdk-lib/aws-s3-deployment';
 import { Provider } from 'aws-cdk-lib/custom-resources';
 import { Construct } from 'constructs';
+
+// Resolved by CloudFormation at deploy time via a dynamic reference, so the actual secret value
+// never appears in the synthesized template (or any CI artifact derived from it) - only this
+// placeholder name does. The secret must exist under this name in Secrets Manager in every
+// account this stack is deployed to.
+export const DASH0_AUTHORIZATION_TOKEN_SECRET_NAME = 'otelbin-validation/dash0-authorization-token';
 
 export interface Distributions {
   [key: string]: Distribution;
@@ -33,7 +39,6 @@ export interface DistributionNestedStackProps extends NestedStackProps {
   distributionName: string;
   distribution: Distribution;
   githubToken: string;
-  dash0AuthorizationToken?: string;
 }
 
 export class DistributionNestedStack extends NestedStack {
@@ -61,7 +66,7 @@ export class DistributionNestedStack extends NestedStack {
         }),
         environment: {
           DISTRO_NAME: props.distributionName,
-          DASH0_AUTHORIZATION_TOKEN: props.dash0AuthorizationToken || '',
+          DASH0_AUTHORIZATION_TOKEN: SecretValue.secretsManager(DASH0_AUTHORIZATION_TOKEN_SECRET_NAME).unsafeUnwrap(),
           SNOWFLAKE_CRL_ON_DISK_CACHE_DIR: '/tmp', // Remediation for https://github.com/snowflakedb/gosnowflake/pull/1526
         },
         /*
@@ -87,7 +92,6 @@ export class DistributionNestedStack extends NestedStack {
 export interface OTelBinValidationStackProps extends StackProps {
   testEnvironmentName: string;
   githubToken: string;
-  dash0AuthorizationToken?: string;
 }
 
 export class OTelBinValidationStack extends Stack {
@@ -207,7 +211,6 @@ export class OTelBinValidationStack extends Stack {
         distributionName,
         distribution,
         githubToken: props.githubToken,
-        dash0AuthorizationToken: props.dash0AuthorizationToken,
       });
       allLambdaFunctions.push(...nestedStack.lambdaFunctions);
     }
@@ -285,7 +288,6 @@ const env = {
   region: process.env.CDK_DEFAULT_REGION,
   testEnvironmentName,
   githubToken: process.env.GH_TOKEN,
-  dash0AuthorizationToken: process.env.DASH0_AUTHORIZATION_TOKEN,
 };
 
 const app = new App();

--- a/packages/otelbin-validation/test/stack.test.ts
+++ b/packages/otelbin-validation/test/stack.test.ts
@@ -86,12 +86,12 @@ describe('OTelBinValidationStack synthesis', () => {
   });
 
   test('the Dash0 authorization token is resolved via a Secrets Manager dynamic reference, never inlined', () => {
-    let sawLambdaFunction = false;
+    const found: { stackName: string; resourceId: string; token: unknown }[] = [];
 
     for (const stackArtifact of assembly.stacks) {
       const resources = stackArtifact.template.Resources || {};
 
-      for (const resource of Object.values(resources)) {
+      for (const [resourceId, resource] of Object.entries(resources)) {
         const typedResource = resource as { Type: string; Properties?: Record<string, unknown> };
         if (typedResource.Type !== 'AWS::Lambda::Function') {
           continue;
@@ -103,11 +103,31 @@ describe('OTelBinValidationStack synthesis', () => {
           continue;
         }
 
-        sawLambdaFunction = true;
-        expect(token).toBe(`{{resolve:secretsmanager:${DASH0_AUTHORIZATION_TOKEN_SECRET_NAME}:SecretString:::}}`);
+        found.push({ stackName: stackArtifact.stackName, resourceId, token });
       }
     }
 
-    expect(sawLambdaFunction).toBe(true);
+    if (found.length === 0) {
+      // Dump every Lambda's Environment and every nested stack's Parameters so a failure here is
+      // debuggable from CI output alone, without needing a local repro.
+      const debugInfo = assembly.stacks.map(stackArtifact => {
+        const resources = stackArtifact.template.Resources || {};
+        return {
+          stackName: stackArtifact.stackName,
+          lambdas: Object.entries(resources)
+            .filter(([, r]) => (r as { Type: string }).Type === 'AWS::Lambda::Function')
+            .map(([id, r]) => ({ id, environment: (r as { Properties?: Record<string, unknown> }).Properties?.Environment })),
+          nestedStackParameters: Object.entries(resources)
+            .filter(([, r]) => (r as { Type: string }).Type === 'AWS::CloudFormation::Stack')
+            .map(([id, r]) => ({ id, parameters: (r as { Properties?: Record<string, unknown> }).Properties?.Parameters })),
+        };
+      });
+      throw new Error(`No Lambda function had a DASH0_AUTHORIZATION_TOKEN environment variable. Debug info:\n${JSON.stringify(debugInfo, null, 2)}`);
+    }
+
+    const expected = `{{resolve:secretsmanager:${DASH0_AUTHORIZATION_TOKEN_SECRET_NAME}:SecretString:::}}`;
+    for (const { stackName, resourceId, token } of found) {
+      expect({ stackName, resourceId, token }).toEqual({ stackName, resourceId, token: expected });
+    }
   });
 });

--- a/packages/otelbin-validation/test/stack.test.ts
+++ b/packages/otelbin-validation/test/stack.test.ts
@@ -13,7 +13,8 @@ process.env.GH_TOKEN = process.env.GH_TOKEN || 'test-token';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, test } from '@jest/globals';
-import { App } from 'aws-cdk-lib';
+import { App, NestedStack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { DASH0_AUTHORIZATION_TOKEN_SECRET_NAME, Distributions, OTelBinValidationStack } from '../src/main';
 
 const CF_MAX_RESOURCES = 500;
@@ -25,6 +26,11 @@ describe('OTelBinValidationStack synthesis', () => {
     githubToken: 'test-token',
   });
   const assembly = app.synth();
+
+  // NestedStack templates are synthesized as assets (referenced via TemplateURL), not as
+  // top-level entries in the cloud assembly - assembly.stacks only has the parent. Template.
+  // fromStack() synthesizes a nested stack's own template directly from the construct instead.
+  const nestedStacks = app.node.findAll().filter((c): c is NestedStack => c instanceof NestedStack);
 
   test('stack is synthesized successfully', () => {
     expect(stack.stackName).toBe('test-stack');
@@ -73,61 +79,34 @@ describe('OTelBinValidationStack synthesis', () => {
   });
 
   test('nested stacks do not create individual Lambda execution roles', () => {
-    const nestedStacks = assembly.stacks.filter(s => s.stackName !== 'test-stack');
+    expect(nestedStacks.length).toBeGreaterThan(0);
 
     for (const nestedStack of nestedStacks) {
-      const resources = nestedStack.template.Resources || {};
-      const iamRoles = Object.values(resources).filter(
-        (r: unknown) => (r as Record<string, unknown>).Type === 'AWS::IAM::Role',
-      );
-
-      expect(iamRoles).toHaveLength(0);
+      Template.fromStack(nestedStack).resourceCountIs('AWS::IAM::Role', 0);
     }
   });
 
   test('the Dash0 authorization token is resolved via a Secrets Manager dynamic reference, never inlined', () => {
-    const found: { stackName: string; resourceId: string; token: unknown }[] = [];
+    expect(nestedStacks.length).toBeGreaterThan(0);
 
-    for (const stackArtifact of assembly.stacks) {
-      const resources = stackArtifact.template.Resources || {};
+    const expected = `{{resolve:secretsmanager:${DASH0_AUTHORIZATION_TOKEN_SECRET_NAME}:SecretString:::}}`;
+    let sawLambdaFunction = false;
 
-      for (const [resourceId, resource] of Object.entries(resources)) {
-        const typedResource = resource as { Type: string; Properties?: Record<string, unknown> };
-        if (typedResource.Type !== 'AWS::Lambda::Function') {
-          continue;
-        }
+    for (const nestedStack of nestedStacks) {
+      const lambdas = Template.fromStack(nestedStack).findResources('AWS::Lambda::Function');
 
-        const variables = (typedResource.Properties?.Environment as { Variables?: Record<string, unknown> } | undefined)?.Variables;
+      for (const resource of Object.values(lambdas)) {
+        const variables = (resource as { Properties?: { Environment?: { Variables?: Record<string, unknown> } } }).Properties?.Environment?.Variables;
         const token = variables?.DASH0_AUTHORIZATION_TOKEN;
         if (token === undefined) {
           continue;
         }
 
-        found.push({ stackName: stackArtifact.stackName, resourceId, token });
+        sawLambdaFunction = true;
+        expect(token).toBe(expected);
       }
     }
 
-    if (found.length === 0) {
-      // Dump every Lambda's Environment and every nested stack's Parameters so a failure here is
-      // debuggable from CI output alone, without needing a local repro.
-      const debugInfo = assembly.stacks.map(stackArtifact => {
-        const resources = stackArtifact.template.Resources || {};
-        return {
-          stackName: stackArtifact.stackName,
-          lambdas: Object.entries(resources)
-            .filter(([, r]) => (r as { Type: string }).Type === 'AWS::Lambda::Function')
-            .map(([id, r]) => ({ id, environment: (r as { Properties?: Record<string, unknown> }).Properties?.Environment })),
-          nestedStackParameters: Object.entries(resources)
-            .filter(([, r]) => (r as { Type: string }).Type === 'AWS::CloudFormation::Stack')
-            .map(([id, r]) => ({ id, parameters: (r as { Properties?: Record<string, unknown> }).Properties?.Parameters })),
-        };
-      });
-      throw new Error(`No Lambda function had a DASH0_AUTHORIZATION_TOKEN environment variable. Debug info:\n${JSON.stringify(debugInfo, null, 2)}`);
-    }
-
-    const expected = `{{resolve:secretsmanager:${DASH0_AUTHORIZATION_TOKEN_SECRET_NAME}:SecretString:::}}`;
-    for (const { stackName, resourceId, token } of found) {
-      expect({ stackName, resourceId, token }).toEqual({ stackName, resourceId, token: expected });
-    }
+    expect(sawLambdaFunction).toBe(true);
   });
 });

--- a/packages/otelbin-validation/test/stack.test.ts
+++ b/packages/otelbin-validation/test/stack.test.ts
@@ -14,7 +14,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, test } from '@jest/globals';
 import { App } from 'aws-cdk-lib';
-import { Distributions, OTelBinValidationStack } from '../src/main';
+import { DASH0_AUTHORIZATION_TOKEN_SECRET_NAME, Distributions, OTelBinValidationStack } from '../src/main';
 
 const CF_MAX_RESOURCES = 500;
 
@@ -83,5 +83,31 @@ describe('OTelBinValidationStack synthesis', () => {
 
       expect(iamRoles).toHaveLength(0);
     }
+  });
+
+  test('the Dash0 authorization token is resolved via a Secrets Manager dynamic reference, never inlined', () => {
+    let sawLambdaFunction = false;
+
+    for (const stackArtifact of assembly.stacks) {
+      const resources = stackArtifact.template.Resources || {};
+
+      for (const resource of Object.values(resources)) {
+        const typedResource = resource as { Type: string; Properties?: Record<string, unknown> };
+        if (typedResource.Type !== 'AWS::Lambda::Function') {
+          continue;
+        }
+
+        const variables = (typedResource.Properties?.Environment as { Variables?: Record<string, unknown> } | undefined)?.Variables;
+        const token = variables?.DASH0_AUTHORIZATION_TOKEN;
+        if (token === undefined) {
+          continue;
+        }
+
+        sawLambdaFunction = true;
+        expect(token).toBe(`{{resolve:secretsmanager:${DASH0_AUTHORIZATION_TOKEN_SECRET_NAME}:SecretString:::}}`);
+      }
+    }
+
+    expect(sawLambdaFunction).toBe(true);
   });
 });


### PR DESCRIPTION
Every open dependabot PR's "Deploy validation backend" job fails with "Credentials could not be loaded" - GitHub withholds all repo secrets from `pull_request`-triggered runs when the actor is `dependabot[bot]`. The credentialed jobs (`prep-itests`, `run-itests`) now additionally run under `pull_request_target`, gated to the `dependabot[bot]` actor only; non-dependabot PRs keep the existing `pull_request` path unchanged.

Since those jobs now run a bumped dependency's `npm ci` in the same job/runner that later holds AWS credentials, both `npm ci` calls now pass `--ignore-scripts` to remove the main install-time code-execution vector.

`DASH0_AUTHORIZATION_TOKEN` was previously read from `process.env` at synth time and baked as a plaintext Lambda environment value into the synthesized CloudFormation template - meaning the real token existed in plaintext inside `cdk.out`. It's now resolved via a CloudFormation dynamic reference (`SecretValue.secretsManager(...)`), so the synthesized template only ever contains a `{{resolve:secretsmanager:...}}` placeholder, resolved server-side by CloudFormation at deploy time. Added a regression test asserting no literal token is ever embedded.