### PR TITLE
Bump lucide-react from 0.468.0 to 1.39.0 in /packages/otelbin

### DIFF
--- a/packages/otelbin/package-lock.json
+++ b/packages/otelbin/package-lock.json
@@ -36,7 +36,7 @@
 				"html-to-image": "^1.11.11",
 				"js-yaml": "^4.3.1",
 				"lodash": "^4.18.1",
-				"lucide-react": "^0.468.0",
+				"lucide-react": "^1.39.0",
 				"monaco-editor": "^0.44.0",
 				"monaco-languageserver-types": "^0.2.3",
 				"monaco-yaml": "^5.1.1",
@@ -11697,12 +11697,12 @@
 			}
 		},
 		"node_modules/lucide-react": {
-			"version": "0.468.0",
-			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
-			"integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.39.0.tgz",
+			"integrity": "sha512-y8nXoEwvqqIsF927NBWXODa4bfMrcUeEb/9sgpwFqg0gUjgn3j5Hznk+v7STmPgZ2iQ11JKlbQGdFRuTOwvYkA==",
 			"license": "ISC",
 			"peerDependencies": {
-				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/lz-string": {

--- a/packages/otelbin/package.json
+++ b/packages/otelbin/package.json
@@ -45,7 +45,7 @@
 		"html-to-image": "^1.11.11",
 		"js-yaml": "^4.3.1",
 		"lodash": "^4.18.1",
-		"lucide-react": "^0.468.0",
+		"lucide-react": "^1.39.0",
 		"monaco-editor": "^0.44.0",
 		"monaco-languageserver-types": "^0.2.3",
 		"monaco-yaml": "^5.1.1",


### PR DESCRIPTION
Manual replacement for #676, which was closed rather than rebased. Dependabot replied "I won't notify you again about this release", so it will not re-offer 1.37.0, and the npm schedule in `.github/dependabot.yml` is `monthly`, so nothing would have re-proposed lucide-react until roughly October. Going to 1.39.0 rather than 1.37.0 because that is current latest and what Dependabot would have landed on next.

## Why this is now a two-line change

#676 failed with six `TS2305` errors because lucide-react 1.0 removed the entire brand icon set. #679 fixed that ahead of time by sourcing `Github` and `Slack` from `~/components/assets/brand-icons`, so nothing in the tree imports them from lucide-react any more. This PR is manifest-only.

I checked the app's full lucide import surface (31 names) against 1.39.0. `Github` and `Slack` were the only casualties and both are already handled. Nothing targets lucide's `.lucide` CSS class and no snapshot test references it, so there is no silent visual regression path either.

## Verification

Run locally against 1.39.0:

- `npm run lint` exits 0. Zero errors, prettier clean, `tsc --noEmit` clean under the repo's `moduleResolution: "node"`. Worth calling out, since lucide 1.x ships an `exports` map with `.mjs` and node10 resolution could plausibly have choked on it. It does not.
- `npm run test` passes 76 tests across 9 suites.

The lockfile diff touches only lucide-react. The one transitive change is its React peer range tightening from `^19.0.0-rc` to `^19.0.0`, which the app's `react@19.2.4` satisfies.

## Two CI issues worth splitting out

Neither is caused by this PR, and I have not fixed either here.

1. `otelbin-verify`, `otelbin-validation-image-verify` and `otelbin-validation-verify` in `.github/workflows/ci.yaml` run under `pull_request_target` for `dependabot[bot]` but check out with no `ref:`, so they build the base branch instead of the PR head. On #676 that produced a green "OTelBin tests" on the very commit the `pull_request` run failed. `prep-itests` and `run-itests` already carry the fix (`ref: ${{ github.event.pull_request.head.sha || github.sha }}`).

2. `clean-up-test-env.yaml:16` uses `group: ${{ github.ref }}` while `ci.yaml:34` uses `group: ${{ github.head_ref || github.ref }}`. For a `pull_request: closed` event those resolve to `refs/pull/<n>/merge` and the branch name respectively, so the two never share a group. The comment above `clean-up-test-env.yaml:16` states they are serialized to protect the shared CloudFormation stack. They are not.

Separately, the `Deploy validation backend` job on #679 hit its `timeout-minutes: 30` at 30.3 minutes and was reported as cancelled. The same job took 28m16s on #676, so it is running right at its own limit and will keep flaking.
