### PR TITLE
Give the validation backend deploy room under its timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,11 @@ jobs:
     name: Deploy validation backend
     needs: ['otelbin-verify', 'otelbin-validation-image-verify', 'otelbin-validation-verify']
     runs-on: 8core_32gb
-    timeout-minutes: 30
+    # The CDK deploy runs a median of ~25 minutes with a p90 of ~29, so a 30 minute limit killed
+    # roughly 8% of runs. A killed job also leaves the per-branch CloudFormation stack mid-deploy,
+    # and reports as `cancelled` rather than `failed`, which reads like a human pressed cancel.
+    # 60 matches `cleanup_test_env` in `clean-up-test-env.yaml`.
+    timeout-minutes: 60
     # Runs for: pushes to main; PRs from non-dependabot actors (via pull_request, which already
     # has secrets for same-repo branches); and dependabot PRs (via pull_request_target only,
     # since pull_request never carries secrets for the dependabot[bot] actor).


### PR DESCRIPTION
Fixes #681.

`prep-itests` (`Deploy validation backend`) had `timeout-minutes: 30`, but the job's runtime has grown to sit right under that limit, so it is now killing unrelated PRs.

Measured across the last 60 CI runs, taking every real execution of the job (24, excluding skipped):

| | minutes |
| --- | --- |
| min | 17.3 |
| median | 24.7 |
| p75 | 27.0 |
| p90 | 29.2 |
| max | 30.3 (the timeout) |

12 of 24 runs finished within five minutes of the limit, and 2 of 24 were killed by it: runs [33500043772](https://github.com/dash0hq/otelbin/actions/runs/33500043772) and [33528179553](https://github.com/dash0hq/otelbin/actions/runs/33528179553), both at 30.3 minutes. The second of those is on #679, a frontend-only change that could not have affected the deploy.

## The change

One value, 30 to 60, plus a comment recording why. 60 is about 2.4x the median and matches `cleanup_test_env` in `clean-up-test-env.yaml`.

`run-itests` at `ci.yaml:291` keeps its 30 minute limit. Those matrix jobs run 1.5 to 3.5 minutes each, so it has plenty of headroom.

## Why raise the limit rather than speed up the deploy

Making the CDK deploy faster is the better long-term fix and this PR does not attempt it. But a timeout is a bad way to discover a job is slow:

- The job is killed mid `cdk deploy`, leaving the per-branch CloudFormation stack in `CREATE_IN_PROGRESS` or `UPDATE_IN_PROGRESS`, which can block the next deploy for that branch and leave AWS resources behind.
- Actions reports a `timeout-minutes` kill with conclusion `cancelled`, indistinguishable in the checks list from someone pressing cancel. That actively misleads whoever is triaging.

So this stops the bleeding. #681 keeps the underlying slowness visible.

## Verification

I cannot exercise a 60 minute timeout locally. What I did check:

- The YAML still parses (`js-yaml`).
- The diff touches exactly one value; `grep -n timeout-minutes` confirms lines 41, 74 and 101 stay at 20 and line 291 stays at 30.

The real check is this PR's own `Deploy validation backend` run completing normally.
