### PR TITLE
Test the PR's own code in the three verify jobs under pull_request_target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # See prep-itests below: under pull_request_target the default checkout is the base
+          # branch (main), which would test main's code and report the result on the PR.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -78,6 +81,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # See prep-itests below: under pull_request_target the default checkout is the base
+          # branch (main), which would test main's code and report the result on the PR.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -105,6 +111,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # See prep-itests below: under pull_request_target the default checkout is the base
+          # branch (main), which would test main's code and report the result on the PR.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
Fixes #683.

Under `pull_request_target` the default checkout is the base branch. `otelbin-verify`, `otelbin-validation-image-verify` and `otelbin-validation-verify` pass no `ref:`, so for Dependabot PRs they build `main` and report the result on the PR.

## The evidence

Both runs below are on the identical head commit `b333077` of #676, a PR that does not compile:

| Run | Event | `OTelBin tests` |
| --- | --- | --- |
| [33520238361](https://github.com/dash0hq/otelbin/actions/runs/33520238361) | `pull_request` | **fail**, six `TS2305` errors |
| [33520231843](https://github.com/dash0hq/otelbin/actions/runs/33520231843) | `pull_request_target` | **pass** |

From the checkout logs. `pull_request`:

```
HEAD is now at f4bbf58 Merge b333077ff901d5d31e0501c735ae67cf05641212 into bf6efc0e04bcc47d17e5c13d61263aabab1bde53
```

`pull_request_target`:

```
[command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
```

Both report under the same `OTelBin tests` name in the checks list, so the green and the red are easy to confuse.

## The change

Three checkout steps gain the `ref:` that `prep-itests` (`ci.yaml:153`) and `run-itests` (`ci.yaml:293`) already carry:

```yaml
ref: ${{ github.event.pull_request.head.sha || github.sha }}
```

After this, all five `actions/checkout` steps in the workflow are consistent. The `|| github.sha` fallback leaves `push` runs on `main` unchanged.

## On the security posture

Checking out PR code under `pull_request_target` is normally the footgun, since the job has secrets. Two reasons this is alignment rather than new exposure:

- `prep-itests` already checks out the PR head under the same event and runs it with AWS credentials, and it `needs:` these three jobs. The PR's code already executes with credentials in this workflow.
- The workflow file still comes from `main` under `pull_request_target`, so a dependency-bump PR cannot rewrite the steps it runs under. The comment at the top of `ci.yaml` already relies on this.

I would still like a look from whoever owns the CI credentials. If the preference is to narrow exposure rather than align, the alternative is dropping `pull_request_target` for these three and having `prep-itests` depend on the `pull_request` run instead, which is a bigger change than I wanted to make unilaterally.

## Verification

The honest limit: I cannot fully exercise this from a non-Dependabot PR, because the `if:` means the `pull_request_target` run skips these jobs for me. This PR's own run will exercise the `pull_request` path and the `|| github.sha` fallback, but the Dependabot path only gets proven on the next Dependabot PR.

What I did check:

- The YAML parses (`js-yaml`).
- All five `actions/checkout` steps now carry the `ref:`, confirmed by script rather than by eye. Lines 51, 86, 116, 162, 302.
- The diff is three identical insertions and touches nothing else.
