### PR TITLE
Serialize the test env teardown against the CI deploy

### DIFF
--- a/.github/workflows/clean-up-test-env.yaml
+++ b/.github/workflows/clean-up-test-env.yaml
@@ -6,14 +6,20 @@ on:
     types: [ closed ]
   workflow_dispatch:
 
-# Use the same group key as `ci.yaml` so a CI deploy and this teardown for
-# the same PR are serialized, and so two teardowns for the same PR (e.g.
-# closed -> reopened -> closed, or a PR close racing a manual dispatch)
-# cannot both hit the same CloudFormation stack at once.
+# Byte-for-byte the same group key as `ci.yaml`, so a CI deploy and this teardown
+# for the same PR are serialized: both resolve `github.head_ref` to the PR's branch
+# name. This also keeps two teardowns for the same PR (e.g. closed -> reopened ->
+# closed) in one group, so they cannot both hit the same CloudFormation stack at
+# once. `github.ref` alone would not do it: under a `pull_request` event it is
+# `refs/pull/<number>/merge`, which never matches `ci.yaml`'s branch-name group.
+# Known gap: under `workflow_dispatch` there is no `head_ref`, so the group falls
+# back to `refs/heads/<branch>`. That matches a `push` run of `ci.yaml` but not a
+# `pull_request` run for the same branch, so a manual teardown can still race a
+# PR's deploy.
 # `cancel-in-progress: false` so a queued run waits for the in-flight one
 # rather than killing the destroy mid-retry-loop.
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Fixes #685

`.github/workflows/clean-up-test-env.yaml:16` used `${{ github.ref }}` as its concurrency group while `.github/workflows/ci.yaml:34` uses `${{ github.head_ref || github.ref }}`. The teardown triggers on `pull_request: [closed]`, where `github.ref` is `refs/pull/<number>/merge`, so for the same PR the two workflows produced different group strings and GitHub never queued one behind the other. Both act on the same CloudFormation stack, so merging or closing a PR during its CI deploy could run `cdk destroy` while `cdk deploy` was still updating that stack.

This changes the teardown's group to exactly `${{ github.head_ref || github.ref }}` and rewrites the comment above it, which previously asserted a serialization that did not happen.

## What the fix does

Under `pull_request`, `github.head_ref` is set, so the teardown resolves to the PR's branch name, the same string `ci.yaml` resolves to for both its `pull_request` and `pull_request_target` runs on that branch. With `cancel-in-progress: false` on both sides, the teardown queues behind an in-flight deploy.

The second claim in the old comment, that two teardowns for the same PR cannot both hit the stack, was checked and still holds: a close, reopen, close sequence produces `pull_request` events on one branch, so every teardown run resolves `head_ref` to the same branch name and shares one group.

## Known remaining gap, not fixed here

`clean-up-test-env.yaml` also triggers on `workflow_dispatch`, where `github.head_ref` is empty and the group falls back to `github.ref`, that is `refs/heads/<branch>`. That matches a `push` run of `ci.yaml` on the same branch, but not a `pull_request` run for that branch, whose group is the bare branch name. A manually dispatched teardown can therefore still race a PR's deploy. Normalizing the key across all four trigger types is a larger change and is deliberately left out. The comment in the file now says so.

## Verification

A real concurrency collision was not tested. Serializing two live GitHub Actions workflows against real CloudFormation cannot be reproduced locally, and no workflow run was triggered for this branch.

Checked:

- `npx js-yaml .github/workflows/clean-up-test-env.yaml` parses the edited file.
- The group expression is now character-identical to `.github/workflows/ci.yaml:34`.
- Both workflows pass `REF_NAME: ${{ github.head_ref || github.ref_name }}` into `.github/workflows/scripts/test_env_name.sh` (`ci.yaml:171-181`, `clean-up-test-env.yaml:40-50`), and both resolve to the stack `otelbin-validation-<test_env_name>` (`ci.yaml:242-244`, `.github/workflows/scripts/destroy-validation-stack.sh:19`).
- These are the only two `concurrency:` blocks under `.github/workflows/`, so no third workflow is affected.
- The diff touches one file and only the `concurrency` block and the comment above it. No job, step, or trigger changed.

Not checked: the exact `github.ref` value GitHub sets for a `pull_request` `closed` event was taken from the documented behavior, not observed in a run of this repository.

## Related, not addressed here

- #681 / #682: `prep-itests` running at its 30 minute timeout. The long deploy window is what makes this race easy to hit, but the timeout is a separate change.
- #683 / #684: the three verify jobs checking out main under `pull_request_target`.
