### PR TITLE
Revert the sdk-trace-node 2.x bump that breaks the validation Lambda

### DIFF
--- a/packages/otelbin-validation-image/package-lock.json
+++ b/packages/otelbin-validation-image/package-lock.json
@@ -23,7 +23,7 @@
 				"@opentelemetry/resources": "^1.18.1",
 				"@opentelemetry/sdk-metrics": "^1.18.1",
 				"@opentelemetry/sdk-trace-base": "^1.18.1",
-				"@opentelemetry/sdk-trace-node": "^2.11.0",
+				"@opentelemetry/sdk-trace-node": "^1.18.1",
 				"aws-lambda": "^1.0.7",
 				"js-yaml": "^4.3.1"
 			},
@@ -1647,12 +1647,11 @@
 			}
 		},
 		"node_modules/@opentelemetry/context-async-hooks": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.11.0.tgz",
-			"integrity": "sha512-Tr79DyWI8itsBdg+jH+opjfrwLzX+erk1/ExkIwhWoAVjVrJIn2y5+cGjTC0Vy8fyNIA/y8wuJPZwr1T3xCZeQ==",
-			"license": "Apache-2.0",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
@@ -2098,6 +2097,78 @@
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
+		"node_modules/@opentelemetry/propagator-b3": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
+			"integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
+			"integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
+			"dependencies": {
+				"@opentelemetry/core": "1.30.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.28.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@opentelemetry/resource-detector-aws": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.12.0.tgz",
@@ -2227,23 +2298,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-trace": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.11.0.tgz",
-			"integrity": "sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.11.0",
-				"@opentelemetry/resources": "2.11.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
 			"version": "1.30.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
@@ -2283,116 +2337,42 @@
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.11.0.tgz",
-			"integrity": "sha512-CuvCMJmZxswhNLlM2LfuLOW3h3fZujA4hsG4B+Sz4dX2zvaXO8Ng74cnDHWD64gLszTlhiG3c0iNUjj4g+0/sA==",
-			"license": "Apache-2.0",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
+			"integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
 			"dependencies": {
-				"@opentelemetry/context-async-hooks": "2.11.0",
-				"@opentelemetry/core": "2.11.0",
-				"@opentelemetry/sdk-trace-base": "2.11.0"
+				"@opentelemetry/context-async-hooks": "1.30.1",
+				"@opentelemetry/core": "1.30.1",
+				"@opentelemetry/propagator-b3": "1.30.1",
+				"@opentelemetry/propagator-jaeger": "1.30.1",
+				"@opentelemetry/sdk-trace-base": "1.30.1",
+				"semver": "^7.5.2"
 			},
 			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
-			"integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
-			"license": "Apache-2.0",
+			"version": "1.30.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
+				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
 			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
+				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/resources": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
-			"integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.11.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.11.0.tgz",
-			"integrity": "sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.11.0",
-				"@opentelemetry/resources": "2.11.0",
-				"@opentelemetry/sdk-trace": "2.11.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
-			"integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
-			"integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/core": "2.11.0",
-				"@opentelemetry/semantic-conventions": "^1.29.0"
-			},
-			"engines": {
-				"node": "^18.19.0 || >=20.6.0"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-			"license": "Apache-2.0",
+			"version": "1.28.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
 			"engines": {
 				"node": ">=14"
 			}

--- a/packages/otelbin-validation-image/package.json
+++ b/packages/otelbin-validation-image/package.json
@@ -49,6 +49,6 @@
 		"@opentelemetry/resources": "^1.18.1",
 		"@opentelemetry/sdk-metrics": "^1.18.1",
 		"@opentelemetry/sdk-trace-base": "^1.18.1",
-		"@opentelemetry/sdk-trace-node": "^2.11.0"
+		"@opentelemetry/sdk-trace-node": "^1.18.1"
 	}
 }


### PR DESCRIPTION
Fixes #687. Reverts b1fde6c (#651).

`main` is currently red and so is every branch based on it. This is the unblocking change for #680, #682, #684 and #686, none of which touch the validation backend.

## The break

#651 moved `@opentelemetry/sdk-trace-node` from `^1.18.1` to `^2.11.0` in `packages/otelbin-validation-image` while every sibling `@opentelemetry/*` package stayed on 1.x. OpenTelemetry JS SDK 2.0 removed `TracerProvider.addSpanProcessor()`, which `src/lambda-wrapper.ts` calls at lines 69 and 74.

The Lambda throws during initialization, so API Gateway answers 502 to every request. That is the exact error all 109 `Validation tests` jobs report.

## Verification

I confirmed the mechanism in both directions rather than inferring it.

Against the broken version currently on `main`:

```
$ node -e 'const {NodeTracerProvider} = require("@opentelemetry/sdk-trace-node"); ...'
sdk-trace-node 2.11.0 -> addSpanProcessor is a function: false
calling it throws: TypeError: p.addSpanProcessor is not a function
```

Against this branch:

```
install ok: sdk-trace-node=1.30.1
NodeTracerProvider.addSpanProcessor is a function: true
resources.detectResourcesSync exported: true
```

Also on this branch, in `packages/otelbin-validation-image`:

- `npm run build` exits 0.
- `npm run test` passes 5 tests.
- `sdk-trace-node`, `sdk-trace-base` and `resources` all resolve to 1.30.1 again, instead of 2.11.0 against 1.30.1.

The revert applied cleanly. Nothing has touched `packages/otelbin-validation-image/` since b1fde6c.

What I cannot verify locally is the 502 clearing, since that needs a deployed stack. The real check is this PR's own `Validation tests` going green, which is also the first time that signal will have been trustworthy since 14:36 UTC.

## Not fixed here

#687 covers the why and the follow-ups. The two that matter most:

- On a Dependabot PR the validation tests only run in the slow `pull_request_target` run, they are not required checks, and #651 was merged 29 minutes before its own run reported red. Nothing was visibly failing at merge time.
- Grouping `@opentelemetry/*` in `.github/dependabot.yml` would have proposed the whole set together instead of letting one package cross a major boundary alone.

Migrating this package to OpenTelemetry JS 2.x properly is its own piece of work: `lambda-wrapper.ts` needs the constructor-based `spanProcessors` API and the 2.x resources API, and every `@opentelemetry/*` dependency has to move together.

## One thing to check outside this PR

The `main` environment deploys with the **prod** credentials (`ci.yaml:198-202`). Every `main` deploy since the bump was killed by the 30 minute timeout in #681, but killing `cdk deploy` does not stop CloudFormation, which continues server-side. Someone should confirm whether the production validation backend picked up the broken image.

Opened as a normal PR rather than a draft, since `main` is broken and this should land as soon as someone can review it.
