### PR TITLE
Skip dependency install scripts in the verify jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,11 @@ on:
     branches:
       - 'main'
 
+# Only `contents: read` is needed. `actions/checkout` reads the repo, and the AWS steps
+# authenticate with static access keys rather than OIDC, so nothing ever requested an OIDC
+# token. Granting `id-token: write` put a requestable token in every job's environment,
+# including the `pull_request_target` jobs that install dependency versions the PR proposes.
 permissions:
-  id-token: write
   contents: read
 
 # Ensure we only have one such workflow running per branch, to avoid
@@ -59,7 +62,11 @@ jobs:
       - name: Install dependencies
         shell: bash
         working-directory: packages/otelbin
-        run: npm ci
+        # --ignore-scripts: under pull_request_target this job installs the dependency versions
+        # the PR proposes, so an install script would execute PR-controlled code. Unlike
+        # prep-itests below, this job references no secrets, so the flag closes the code
+        # execution path itself rather than protecting credentials from it.
+        run: npm ci --ignore-scripts
 
       - name: Lint
         shell: bash
@@ -94,7 +101,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         working-directory: packages/otelbin-validation-image
-        run: npm ci
+        # See otelbin-verify above for why --ignore-scripts is used here.
+        run: npm ci --ignore-scripts
 
       - name: Test
         shell: bash
@@ -124,7 +132,8 @@ jobs:
       - name: Install dependencies
         shell: bash
         working-directory: packages/otelbin-validation
-        run: npm ci
+        # See otelbin-verify above for why --ignore-scripts is used here.
+        run: npm ci --ignore-scripts
 
       - name: Unit tests
         shell: bash


### PR DESCRIPTION
Two changes to `.github/workflows/ci.yaml`, both small:

1. `npm ci` becomes `npm ci --ignore-scripts` in the three verify jobs: `otelbin-verify`, `otelbin-validation-image-verify` and `otelbin-validation-verify`.
2. The workflow-level `id-token: write` is dropped, leaving `contents: read`.

## Why `--ignore-scripts`

npm runs `preinstall`, `install` and `postinstall` during `npm ci`, so a dependency's install script executes arbitrary code in the job. Under `pull_request_target` these three jobs check out and install the dependency versions the pull request proposes, which makes that code PR-controlled. That checkout behavior is what #684 established.

The two credentialed jobs already pass the flag, and `prep-itests` carries the rationale:

```
# --ignore-scripts: this job configures AWS credentials in a later step; skipping
# install-time scripts prevents a compromised/malicious dependency from planting
# something in this job that later reads those credentials from the shared runner env.
```

That specific rationale does **not** transfer to the verify jobs, so I wrote a different comment rather than copying it. Bounding the exposure honestly: the three verify jobs reference no secrets and run on ephemeral `ubuntu-latest`. The AWS credentials appear only in `prep-itests` and `run-itests`. What an install script can reach in a verify job is the `GITHUB_TOKEN`, already narrowed to `contents: read`, and, before this PR, a requestable OIDC token.

So this is not a "credentials are leaking" fix. It closes an arbitrary code execution path that has no reason to be open, and it makes the three verify jobs consistent with the two that already do this.

## Why drop `id-token: write`

No step requests an OIDC token. Both `aws-actions/configure-aws-credentials` calls authenticate with static keys plus a role to assume, which is an `sts:AssumeRole` with credentials, not a web-identity exchange:

```yaml
- name: Configure AWS credentials
  uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
  with:
    aws-access-key-id: ${{ steps.select_credentials.outputs.aws_access_key }}
    aws-secret-access-key: ${{ steps.select_credentials.outputs.aws_secret_access_key }}
    aws-region: 'us-east-2'
    mask-aws-account-id: true
    role-to-assume: ${{ steps.select_credentials.outputs.role_arn }}
```

`id-token: write` makes the runner place `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` in the environment of every job in the workflow. Nothing reads them. The only other action used anywhere in `ci.yaml` is `actions/checkout` and `actions/setup-node`, neither of which requests one.

If moving the AWS auth to OIDC is planned, and it would be an improvement over static keys, the right move then is to grant `id-token: write` on the specific job that needs it rather than keep it workflow-wide now.

## Verification

I ran the exact commands CI runs, locally, on node 22.23.2 to match `.nvmrc`. All eight steps exited 0.

| Package | `npm ci --ignore-scripts` | Test commands |
| --- | --- | --- |
| `packages/otelbin-validation-image` | pass | `npm run test` pass |
| `packages/otelbin-validation` | pass | `npx jest src/` pass, `npx jest test/stack.test.ts` pass |
| `packages/otelbin` | pass | `npm run lint` pass, `npm run test` pass |

`npm run lint` in `packages/otelbin` is the one that mattered. It runs `eslint . && npm run prettier:check && tsc --noEmit`, and eslint's import resolution goes through `unrs-resolver`, which has an install script. It resolves correctly without its postinstall.

For completeness, the dependencies that declare install scripts, per `hasInstallScript` in the lockfiles:

- `packages/otelbin`: `@clerk/shared`, `unrs-resolver`, `fsevents` (optional, macOS only)
- `packages/otelbin-validation`: `aws-sdk`, `esbuild`, `unrs-resolver`, `fsevents`
- `packages/otelbin-validation-image`: `aws-sdk`, `esbuild`, `protobufjs`, `unrs-resolver`, `fsevents`

None is needed for the commands these jobs run. `esbuild` matters for `npm run build`, which these jobs do not invoke, and its binary resolves through its optional platform packages.

## Risk

Low, and it fails safe. If an install script turns out to be needed in a way the local run did not exercise, the symptom is a red verify job on this pull request, not a broken `main`.

Left as draft until CI confirms it on the runners.
