### PR TITLE
Add a single fixed-name gate job so CI can be required on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -390,3 +390,62 @@ jobs:
 
           echo "::add-mask::${VALIDATION_API_KEY}"
           VALIDATION_API_KEY="${VALIDATION_API_KEY}" npm run test
+
+  # A single fixed-name check, so that the validation suite can actually be required on main.
+  # `run-itests` is a matrix whose legs are named from supported-distributions.json, so it
+  # reports ~109 differently-named checks and the set changes whenever that file changes. No
+  # fixed list of context names can cover it. This job collapses every job above into one name.
+  ci-gate:
+    name: CI passed
+    needs:
+      - otelbin-verify
+      - otelbin-validation-image-verify
+      - otelbin-validation-verify
+      - prep-itests
+      - run-itests
+    # `always()` is load-bearing: without it this job is skipped whenever a dependency fails,
+    # and a skipped check does not block a merge, which would make the gate worse than useless.
+    # `!cancelled()` would have the same defect for a cancelled run.
+    #
+    # The event/actor condition is copied from prep-itests deliberately. Both the pull_request
+    # and pull_request_target runs report to the same head commit, and in every PR exactly one
+    # of them legitimately skips the itests: the pull_request run for dependabot, the
+    # pull_request_target run for everyone else. Without this condition, that run would report
+    # a spurious failure under this same check name. With it, that run reports `skipped`
+    # instead, which is the same shape the already-required `OTelBin tests` check produces on
+    # every PR today.
+    if: |
+      always() && (
+        github.event_name == 'push' ||
+        (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') ||
+        (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail unless every upstream job succeeded
+        shell: bash
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        # language=bash
+        run: |
+          set -euo pipefail
+
+          echo "${NEEDS_JSON}" | jq .
+
+          # Treat anything other than `success` as a failure, `skipped` included. A skipped
+          # itest job is precisely the hole this gate closes: prep-itests failing skips
+          # run-itests, and an empty test matrix produces no legs at all. Reporting success in
+          # either case would mean the validation suite never ran and nobody noticed.
+          not_succeeded=$(
+            echo "${NEEDS_JSON}" \
+              | jq -r 'to_entries[] | select(.value.result != "success") | "  \(.key): \(.value.result)"'
+          )
+
+          if [ -n "${not_succeeded}" ]; then
+            echo "::error::Not every upstream job succeeded:"
+            echo "${not_succeeded}"
+            exit 1
+          fi
+
+          echo 'Every upstream job succeeded.'


### PR DESCRIPTION
Part of #690.

Adds one job, `ci-gate`, reporting a check named **`CI passed`**. Pure addition: 59 lines, nothing removed.

## Why this is needed

`main`'s required status checks are `call-workflow / cla`, `Vercel` and `OTelBin tests`. The validation suite is not among them, which is half of why #651 merged green and broke `main`.

It is not simply an oversight. `run-itests` is a matrix built from `needs.prep-itests.outputs.test_matrix`, so its check names come from `supported-distributions.json`:

```
Validation tests (otelcol-core/v0.155.0)
Validation tests (splunk-otel-collector/v0.136.1)
Validation tests (adot/v0.48.0)
...  109 of them on the last full run
```

The set changes whenever that file changes, so no fixed list of context names can cover it. A single collapsing job is the only way to make the suite requireable.

## Three design decisions, each with a failure mode behind it

**`always()` is load-bearing.** Without it, the job is skipped whenever a dependency fails, and a skipped check does not block a merge. A gate that disappears exactly when something breaks is worse than no gate. `!cancelled()` has the same defect for a cancelled run, so it is not an alternative.

**`skipped` and `cancelled` count as failures.** The step requires every upstream job to report `success`. That is deliberate, and each non-success state corresponds to something that has actually happened here:

- `prep-itests` fails, so `run-itests` is skipped
- an empty test matrix produces no legs at all
- `timeout-minutes` kills a job, which Actions reports as `cancelled`, not `failed` (this is what made #682 look like a manual cancellation)

**The event/actor condition is copied from `prep-itests` on purpose.** Both the `pull_request` and `pull_request_target` runs report checks to the same head commit, and in every PR exactly one of them legitimately skips the itests:

| PR author | `pull_request` run | `pull_request_target` run |
| --- | --- | --- |
| `dependabot[bot]` | 3 verify jobs run, itests skip | all 5 run |
| anyone else | all 5 run | all 5 skip |

Without the condition, the run with legitimate skips would report a spurious **failure** under this same check name. With it, that run reports `skipped` instead, which is the same shape the already-required `OTelBin tests` check produces on every PR in this repo today. This inherits the existing proven pattern rather than introducing a new one.

## Verification

**actionlint, diffed against `main` to prove nothing new was introduced:**

```
main findings: 14   new findings: 14
diff => IDENTICAL
```

`main` already has 14 findings (the `8core_32gb` custom runner label plus shellcheck style notes in `prep-itests` and `run-itests`). The gate job adds zero, including zero shellcheck findings in its script.

**The decision logic, exercised directly against every upstream state it can observe:**

| Upstream state | Gate | Correct |
| --- | --- | --- |
| all five succeed | pass | yes |
| `run-itests: failure` (the #651 case) | fail | yes |
| `run-itests: skipped` (prep-itests died) | fail | yes |
| `prep-itests: failure` + `run-itests: skipped` | fail | yes |
| `run-itests: cancelled` (the timeout case) | fail | yes |
| a verify job failed | fail | yes |
| everything skipped | fail | yes |

What a reviewer sees on failure:

```
::error::Not every upstream job succeeded:
  prep-itests: failure
  run-itests: skipped
```

## Required follow-up, and it needs admin

This PR only creates the job. Requiring it is a repository setting, and it must happen **after** this merges, or every PR blocks on a context that never reports:

```bash
gh api --method POST \
  repos/dash0hq/otelbin/branches/main/protection/required_status_checks/contexts \
  -f 'contexts[]=CI passed'
```

`OTelBin tests` can stay required alongside it. That becomes redundant, since `ci-gate` covers it, but redundant is harmless and removing it is a separate decision.

## Known limitation

The gate covers exactly the jobs listed in its `needs`. If someone adds a new job to `ci.yaml` and does not add it to that list, the gate silently does not cover it. Nothing enforces the coupling. I considered asserting an expected job count in the script, but that has to be maintained in the same two places, so it trades one silent gap for another. Flagging it rather than papering over it.

Left as draft until CI confirms the gate reports green on this PR.
