### PR TITLE
Group @opentelemetry/* dependabot updates into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,18 @@ updates:
       - "/packages/otelbin-validation-image"
     schedule:
       interval: "monthly"
+    # The OpenTelemetry JS packages have to move in lockstep. The stable ones version at 1.x
+    # and 2.x while the experimental exporters and instrumentations version at 0.x, and a
+    # given experimental release only works against one stable major. Bumping a single
+    # package across that boundary is what broke main: @opentelemetry/sdk-trace-node went to
+    # 2.x on its own, and 2.x removed TracerProvider.addSpanProcessor out from under
+    # packages/otelbin-validation-image/src/lambda-wrapper.ts. Grouping them means such a
+    # bump arrives as one pull request that passes or fails as a set, instead of one that
+    # looks harmless and is not.
+    groups:
+      opentelemetry:
+        patterns:
+          - "@opentelemetry/*"
     pull-request-branch-name:
       # Separate sections of the branch name with a hyphen
       # for example, `dependabot-npm_and_yarn-next_js-acorn-6.4.1`


### PR DESCRIPTION
Completes #690, alongside #700.

Adds a `groups` entry to the npm ecosystem in `.github/dependabot.yml`. 12 lines, 8 of which are a comment.

## Why

`packages/otelbin-validation-image` depends on **14** `@opentelemetry/*` packages, and they span three version families:

| Package | Version | Family |
| --- | --- | --- |
| `@opentelemetry/api` | `^1.7.0` | stable |
| `@opentelemetry/sdk-trace-node` | `^1.18.1` | stable 1.x |
| `@opentelemetry/sdk-trace-base` | `^1.18.1` | stable 1.x |
| `@opentelemetry/resources` | `^1.18.1` | stable 1.x |
| `@opentelemetry/sdk-metrics` | `^1.18.1` | stable 1.x |
| `@opentelemetry/resource-detector-aws` | `^1.3.4` | stable 1.x |
| `@opentelemetry/exporter-trace-otlp-proto` | `^0.50.0` | experimental |
| `@opentelemetry/exporter-metrics-otlp-proto` | `^0.50.0` | experimental |
| `@opentelemetry/instrumentation` | `^0.50.0` | experimental |
| `@opentelemetry/instrumentation-aws-lambda` | `^0.40.0` | experimental |
| `@opentelemetry/instrumentation-aws-sdk` | `^0.40.0` | experimental |
| `@opentelemetry/instrumentation-dns` | `^0.35.0` | experimental |
| `@opentelemetry/instrumentation-http` | `^0.35.0` | experimental |
| `@opentelemetry/instrumentation-net` | `^0.35.0` | experimental |

The stable packages version at 1.x and 2.x while the experimental exporters and instrumentations version at 0.x, and a given experimental release only works against one stable major. They are not independent dependencies that happen to share a prefix. They are one dependency with 14 package names.

Bumping one across the stable major boundary in isolation is what broke `main`. #651 took `@opentelemetry/sdk-trace-node` to 2.x on its own, and 2.x removed `TracerProvider.addSpanProcessor()`, which `packages/otelbin-validation-image/src/lambda-wrapper.ts` calls at lines 69 and 74. Reverted in #688.

Grouping them means such a bump arrives as one pull request that passes or fails as a set. It does not make the migration easier, and it is not meant to: #691 tracks the actual move to SDK 2.x. What it does is stop a breaking change from arriving disguised as a routine single-package bump.

## Scope of the change, deliberately narrow

**Only `@opentelemetry/*`.** Other coupled families exist in this repo, notably the AWS SDK packages, but grouping those is a separate judgement call and this change is meant to close the hole that actually caused an outage.

**Version updates only.** `groups` defaults to `applies-to: version-updates`, and I left that default in place. A second group for `security-updates` would batch security fixes too, and batching means one unupdatable package in the group can hold back the rest. That is a bad trade for security updates, so they continue to arrive individually.

## Verification

Validated against both the vendored Dependabot schema and the exact schemastore schema the file's own header points at:

```
$ check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
ok -- validation done

$ check-jsonschema --schemafile https://json.schemastore.org/dependabot-2.0.json .github/dependabot.yml
ok -- validation done
```

I cannot test the grouping behavior directly. Dependabot only reveals it on the next scheduled run, and the schedule here is `monthly`. The schema check plus the narrow blast radius, one added key in one ecosystem entry, is the extent of what is verifiable before merge. Worth saying plainly rather than implying more confidence than I have.

Left as draft until CI is green.
