### PR TITLE
Migrate otelbin-validation-image to OpenTelemetry JS SDK 2.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,15 @@ jobs:
         # See otelbin-verify above for why --ignore-scripts is used here.
         run: npm ci --ignore-scripts
 
+      # This package is bundled by esbuild, which strips types without checking them, so nothing in
+      # CI ever compared the source against the types of its dependencies. That is how the SDK 2.0
+      # removal of TracerProvider.addSpanProcessor() got through a green build and reached a
+      # deployed Lambda, where it surfaced as an HTTP 502 from API Gateway.
+      - name: Typecheck
+        shell: bash
+        working-directory: packages/otelbin-validation-image
+        run: npm run typecheck
+
       - name: Test
         shell: bash
         working-directory: packages/otelbin-validation-image

--- a/packages/otelbin-validation-image/package-lock.json
+++ b/packages/otelbin-validation-image/package-lock.json
@@ -10,20 +10,21 @@
 			"license": "Apache 2",
 			"dependencies": {
 				"@expo/spawn-async": "^1.7.2",
-				"@opentelemetry/api": "^1.7.0",
-				"@opentelemetry/exporter-metrics-otlp-proto": "^0.50.0",
-				"@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",
-				"@opentelemetry/instrumentation": "^0.50.0",
-				"@opentelemetry/instrumentation-aws-lambda": "^0.40.0",
-				"@opentelemetry/instrumentation-aws-sdk": "^0.40.0",
-				"@opentelemetry/instrumentation-dns": "^0.35.0",
-				"@opentelemetry/instrumentation-http": "^0.35.0",
-				"@opentelemetry/instrumentation-net": "^0.35.0",
-				"@opentelemetry/resource-detector-aws": "^1.3.4",
-				"@opentelemetry/resources": "^1.18.1",
-				"@opentelemetry/sdk-metrics": "^1.18.1",
-				"@opentelemetry/sdk-trace-base": "^1.18.1",
-				"@opentelemetry/sdk-trace-node": "^1.18.1",
+				"@opentelemetry/api": "^1.9.1",
+				"@opentelemetry/core": "^2.11.0",
+				"@opentelemetry/exporter-metrics-otlp-proto": "^0.222.0",
+				"@opentelemetry/exporter-trace-otlp-proto": "^0.222.0",
+				"@opentelemetry/instrumentation": "^0.222.0",
+				"@opentelemetry/instrumentation-aws-lambda": "^0.74.0",
+				"@opentelemetry/instrumentation-aws-sdk": "^0.77.0",
+				"@opentelemetry/instrumentation-dns": "^0.65.0",
+				"@opentelemetry/instrumentation-http": "^0.222.0",
+				"@opentelemetry/instrumentation-net": "^0.66.0",
+				"@opentelemetry/resource-detector-aws": "^2.22.0",
+				"@opentelemetry/resources": "^2.11.0",
+				"@opentelemetry/sdk-metrics": "^2.11.0",
+				"@opentelemetry/sdk-trace-base": "^2.11.0",
+				"@opentelemetry/sdk-trace-node": "^2.11.0",
 				"aws-lambda": "^1.0.7",
 				"js-yaml": "^4.3.1"
 			},
@@ -35,7 +36,8 @@
 				"@types/node": "^20.8.10",
 				"esbuild": "^0.28.1",
 				"jest": "^30.3.0",
-				"ts-jest": "^29.4.9"
+				"ts-jest": "^29.4.9",
+				"typescript": "^5.9.3"
 			},
 			"engines": {
 				"node": "v22.x"
@@ -1628,759 +1630,379 @@
 			}
 		},
 		"node_modules/@opentelemetry/api": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
-			"integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+			"integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/api-logs": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
-			"integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.222.0.tgz",
+			"integrity": "sha512-9mb1If+IF6u0ZVXkHQ6ogEae5HwA6ajIVUgpSDQyRASxft6BSXHvBvPooRle3yFN/fKnCdSOnuu0OC3PLcF6+g==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/context-async-hooks": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.11.0.tgz",
+			"integrity": "sha512-Tr79DyWI8itsBdg+jH+opjfrwLzX+erk1/ExkIwhWoAVjVrJIn2y5+cGjTC0Vy8fyNIA/y8wuJPZwr1T3xCZeQ==",
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/core": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
-			"integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+			"integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.23.0"
+				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
+				"@opentelemetry/api": ">=1.0.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.50.0.tgz",
-			"integrity": "sha512-DMilj0pTOGxeaRPvVBil/KugvLMV5l+GzoXEWBKXYGEnfNlX+huPeMpYl+zJJBtI3Coht2KArnNOLhs2wqA3yA==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.222.0.tgz",
+			"integrity": "sha512-6Ko+0bgNP6V4G/RsmNBSk5lO1B/lo9z6tvLpFY3ykPPevXNzFmOW3C9hEmTt0zKCvHovyrol3TYlg4HVb5gwjg==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/otlp-exporter-base": "0.50.0",
-				"@opentelemetry/otlp-transformer": "0.50.0",
-				"@opentelemetry/resources": "1.23.0",
-				"@opentelemetry/sdk-metrics": "1.23.0"
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/otlp-exporter-base": "0.222.0",
+				"@opentelemetry/otlp-transformer": "0.222.0",
+				"@opentelemetry/resources": "2.11.0",
+				"@opentelemetry/sdk-metrics": "2.11.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
-			"integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/semantic-conventions": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
-			"integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/resources": "1.23.0",
-				"lodash.merge": "^4.6.2"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.9.0"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.50.0.tgz",
-			"integrity": "sha512-1kDjDgA9dF7GRp9Dd22MbY+WXXdPPiHLo4E9LWRyJG9E/hZkRy2zapOa/nWhadvG+4Ji65MRhPrZUvnqC/INww==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.222.0.tgz",
+			"integrity": "sha512-s1ZPwS8Ig7cpRmL3kCobPaFbemM81dJ03LNPrsuN32h3mCDvNF2NQ1pRHruOju0P0o1TZ24LkZA685rtQal1KA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
-				"@opentelemetry/otlp-exporter-base": "0.50.0",
-				"@opentelemetry/otlp-proto-exporter-base": "0.50.0",
-				"@opentelemetry/otlp-transformer": "0.50.0",
-				"@opentelemetry/resources": "1.23.0",
-				"@opentelemetry/sdk-metrics": "1.23.0"
+				"@opentelemetry/exporter-metrics-otlp-http": "0.222.0",
+				"@opentelemetry/otlp-exporter-base": "0.222.0",
+				"@opentelemetry/otlp-transformer": "0.222.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
-			"integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/semantic-conventions": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
-			"integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/resources": "1.23.0",
-				"lodash.merge": "^4.6.2"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.9.0"
-			}
-		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.50.0.tgz",
-			"integrity": "sha512-vavD9Ow6yOLiD+ocuS/oeciCsXNdsN41aYUrEljNaLXogvnkfMhJ+JLAhOnRSpzlVtRp7Ciw2BYGdYSebR0OsA==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.222.0.tgz",
+			"integrity": "sha512-imLrLzNhnABJt3tUyT63h6MqfZrG3Gdv3TE7+OUQTvwD088RfCUx3rF01lcgfu2KXBFk13vwi0yKZLvFEalkIA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/otlp-exporter-base": "0.50.0",
-				"@opentelemetry/otlp-proto-exporter-base": "0.50.0",
-				"@opentelemetry/otlp-transformer": "0.50.0",
-				"@opentelemetry/resources": "1.23.0",
-				"@opentelemetry/sdk-trace-base": "1.23.0"
+				"@opentelemetry/otlp-exporter-base": "0.222.0",
+				"@opentelemetry/otlp-transformer": "0.222.0",
+				"@opentelemetry/sdk-trace": "2.11.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
-			"integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/semantic-conventions": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
-			"integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/resources": "1.23.0",
-				"@opentelemetry/semantic-conventions": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
+				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.50.0.tgz",
-			"integrity": "sha512-bhGhbJiZKpuu7wTaSak4hyZcFPlnDeuSF/2vglze8B4w2LubcSbbOnkVTzTs5SXtzh4Xz8eRjaNnAm+u2GYufQ==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.222.0.tgz",
+			"integrity": "sha512-fhbRDuAgzPKpq1k5+hX3uS+3QAYNca0on0Ngot/R8dDsQtuFaADeZnG2uSgxABuvcI7S2phAaRhbct9jieeKZw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.50.0",
-				"@types/shimmer": "^1.0.2",
-				"import-in-the-middle": "1.7.1",
-				"require-in-the-middle": "^7.1.1",
-				"semver": "^7.5.2",
-				"shimmer": "^1.2.1"
+				"@opentelemetry/api-logs": "0.222.0",
+				"import-in-the-middle": "^3.0.0",
+				"require-in-the-middle": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-aws-lambda": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.40.0.tgz",
-			"integrity": "sha512-DF1Ja1AQNV8K5tAW4STcI0KKuu1IDzCM1aa66UDbJwZfEMq0QedzKS7FjoIB+wV4Mk8+WJQRtzISFmjDiquxmw==",
+			"version": "0.74.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.74.0.tgz",
+			"integrity": "sha512-N7L+NIyndEUWC0EjtN7OmNBF0J5beXQ81+46qt1NCA2YDC95os9TIh2iWfKL+U3wINkJeStMWBEQgFZhEvj1qw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.50.0",
-				"@opentelemetry/propagator-aws-xray": "^1.3.1",
-				"@opentelemetry/resources": "^1.8.0",
-				"@opentelemetry/semantic-conventions": "^1.0.0",
-				"@types/aws-lambda": "8.10.122"
+				"@opentelemetry/instrumentation": "^0.222.0",
+				"@opentelemetry/propagator-aws-xray": "^2.1.4",
+				"@opentelemetry/semantic-conventions": "^1.27.0",
+				"@types/aws-lambda": "^8.10.155"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
-		"node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@types/aws-lambda": {
-			"version": "8.10.122",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.122.tgz",
-			"integrity": "sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw=="
-		},
 		"node_modules/@opentelemetry/instrumentation-aws-sdk": {
-			"version": "0.40.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.40.0.tgz",
-			"integrity": "sha512-USjyLBbpYIp4YPcTqcvspSmckZ/i2r/LSBkcoiIfCGNsbWyEK3mBDUTV3ULL6cuA0zGvYAabNDFZ2qm5vCvAuw==",
+			"version": "0.77.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.77.0.tgz",
+			"integrity": "sha512-igri8DF7ZWlYtQjT1u2A3v6Grb59VSsYiheGrLpnI7rlEAxmFeWHPwiwzzko39lM0LO7Ntf3VJPRBA1ZNGwF1w==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "^1.8.0",
-				"@opentelemetry/instrumentation": "^0.50.0",
-				"@opentelemetry/propagation-utils": "^0.30.8",
-				"@opentelemetry/semantic-conventions": "^1.0.0"
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/instrumentation": "^0.222.0",
+				"@opentelemetry/semantic-conventions": "^1.34.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-dns": {
-			"version": "0.35.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.35.0.tgz",
-			"integrity": "sha512-ci7hIJcp8AWsJntRMt397VGYh2Isou/u8nDX/fPa9nlbIR6VssgcHTpAV6j98Q2+N3/kTPcdTs/WtLI2g8Wwgg==",
+			"version": "0.65.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.65.0.tgz",
+			"integrity": "sha512-7QXICs4eV/GeihRqPnsR7TnK6ugAK8/B7tWr8UFxRzGTfNG97LEfByevhNfMEE8pFFLHUhiCE5metED2lO8nhw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.50.0",
-				"@opentelemetry/semantic-conventions": "^1.0.0",
-				"semver": "^7.5.4"
+				"@opentelemetry/instrumentation": "^0.222.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-http": {
-			"version": "0.35.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.35.1.tgz",
-			"integrity": "sha512-tH92LznX5pcxpuTSb6A662IdldlMk8QTtneDN66h4nIT9ch98Gtu68GSSKjMoTR25GzH3opvPC9mX2xJamxMJw==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.222.0.tgz",
+			"integrity": "sha512-HhMHW32LyGzIJEmUElxaML4oUe6JiCq0Hvjt/Awxb60SlMsSFetFLFjed45g/0wrPr1n7z+xW+x1B/584WBAkg==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.9.1",
-				"@opentelemetry/instrumentation": "0.35.1",
-				"@opentelemetry/semantic-conventions": "1.9.1",
-				"semver": "^7.3.5"
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/instrumentation": "0.222.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0",
+				"forwarded-parse": "2.1.2"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
-			"integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.9.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.5.0"
-			}
-		},
-		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
-			"version": "0.35.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.35.1.tgz",
-			"integrity": "sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==",
-			"dependencies": {
-				"require-in-the-middle": "^5.0.3",
-				"semver": "^7.3.2",
-				"shimmer": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.3.0"
-			}
-		},
-		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
-			"integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@opentelemetry/instrumentation-http/node_modules/require-in-the-middle": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
-			"integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"module-details-from-path": "^1.0.3",
-				"resolve": "^1.22.1"
-			},
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/@opentelemetry/instrumentation-net": {
-			"version": "0.35.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.35.0.tgz",
-			"integrity": "sha512-L5qw1G7vwxuePpuLKxpbIg49wH0brfgVhbMaMa09YX4HM6yj1KQRRGMMFxB00NQo2u42kuv/7F7AB/lWeG0yUA==",
+			"version": "0.66.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.66.0.tgz",
+			"integrity": "sha512-OxnzC0696+Ne7zHisHo95RZkYT4e2C4OoB+q0dqQyZ0/9klLQ9CyC/Yu+OzYrQzPjdzRQVVPNDhoW+5+cXk3XQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/instrumentation": "^0.50.0",
-				"@opentelemetry/semantic-conventions": "^1.0.0"
+				"@opentelemetry/instrumentation": "^0.222.0",
+				"@opentelemetry/semantic-conventions": "^1.33.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-exporter-base": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.50.0.tgz",
-			"integrity": "sha512-JUmjmrCmE1/fc4LjCQMqLfudgSl5OpUkzx7iA94b4jgeODM7zWxUoVXL7/CT7fWf47Cn+pmKjMvTCSESqZZ3mA==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.222.0.tgz",
+			"integrity": "sha512-YbywG3veEm2Fb6TbdxRkuquWob6eVWXuA8/Ba1tXz9jHfUqpdE3keilOHEtPboC4CvS1bjeeVfNkWGOOrLj+lw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.23.0"
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/otlp-transformer": "0.222.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-proto-exporter-base": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.50.0.tgz",
-			"integrity": "sha512-hlbn3eZbhxoK79Sq1ddj1f7qcx+PzsPQC/SFpJvaWgTaqacCbqJmpzWDKfRRCAC7iGX2Hj/sgpf8vysazqyMOw==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/otlp-exporter-base": "0.50.0",
-				"protobufjs": "^7.2.3"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-transformer": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
-			"integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.222.0.tgz",
+			"integrity": "sha512-/F3BZ89+CJQnZkMh2tCrtcdB+XT2Dxhj4FFE+WPQ//413hmFL0/RfEX6vgOIWGhiSzrkHWTK3+6SiT7K5/g/jQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/api-logs": "0.50.0",
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/resources": "1.23.0",
-				"@opentelemetry/sdk-logs": "0.50.0",
-				"@opentelemetry/sdk-metrics": "1.23.0",
-				"@opentelemetry/sdk-trace-base": "1.23.0"
+				"@opentelemetry/api-logs": "0.222.0",
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/resources": "2.11.0",
+				"@opentelemetry/sdk-logs": "0.222.0",
+				"@opentelemetry/sdk-metrics": "2.11.0",
+				"@opentelemetry/sdk-trace": "2.11.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
-			"integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/semantic-conventions": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
-			"integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/resources": "1.23.0",
-				"lodash.merge": "^4.6.2"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.3.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
-			"integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/resources": "1.23.0",
-				"@opentelemetry/semantic-conventions": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagation-utils": {
-			"version": "0.30.16",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.16.tgz",
-			"integrity": "sha512-ZVQ3Z/PQ+2GQlrBfbMMMT0U7MzvYZLCPP800+ooyaBqm4hMvuQHfP028gB9/db0mwkmyEAMad9houukUVxhwcw==",
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.0.0"
+				"@opentelemetry/api": "^1.3.0"
 			}
 		},
 		"node_modules/@opentelemetry/propagator-aws-xray": {
-			"version": "1.26.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.26.2.tgz",
-			"integrity": "sha512-k43wxTjKYvwfce9L4eT8fFYy/ATmCfPHZPZsyT/6ABimf2KE1HafoOsIcxLOtmNSZt6dCvBIYCrXaOWta20xJg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-2.2.0.tgz",
+			"integrity": "sha512-Yjvt2EjL+tfpkVOdKbhTPgpM4SIAez9nG6Q/QjQ3yfcJcjIWp59ph70SLfvmkSL6++3DCnuBG3iWcB18PwWavQ==",
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-b3": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
-			"integrity": "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-jaeger": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
-			"integrity": "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/resource-detector-aws": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.12.0.tgz",
-			"integrity": "sha512-Cvi7ckOqiiuWlHBdA1IjS0ufr3sltex2Uws2RK6loVp4gzIJyOijsddAI6IZ5kiO8h/LgCWe8gxPmwkTKImd+Q==",
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.22.0.tgz",
+			"integrity": "sha512-3kM+xfsSHs0hShUAx9IFhX5jniaXxJL3CTjbCMNCFS+EY7bswWbukV3au0jfqEgzeNxGxHEy8RLA1TOhAVLpTQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "^1.0.0",
-				"@opentelemetry/resources": "^1.10.0",
+				"@opentelemetry/core": "^2.0.0",
+				"@opentelemetry/resources": "^2.0.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0"
 			}
 		},
-		"node_modules/@opentelemetry/resource-detector-aws/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.32.0.tgz",
-			"integrity": "sha512-s0OpmpQFSfMrmedAn9Lhg4KWJELHCU6uU9dtIJ28N8UGhf9Y55im5X8fEzwhwDwiSqN+ZPSNrDJF7ivf/AuRPQ==",
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/@opentelemetry/resources": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+			"integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/semantic-conventions": "1.28.0"
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs": {
-			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
-			"integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/resources": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.4.0 <1.9.0",
-				"@opentelemetry/api-logs": ">=0.39.1"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
-			"integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
-			"dependencies": {
-				"@opentelemetry/core": "1.23.0",
-				"@opentelemetry/semantic-conventions": "1.23.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.9.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-metrics": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
-			"integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
-			"dependencies": {
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/resources": "1.30.1"
-			},
-			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+		"node_modules/@opentelemetry/sdk-logs": {
+			"version": "0.222.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.222.0.tgz",
+			"integrity": "sha512-+19YHODIjaUCArxleaJtuufFZVpz/xvvK+VllQqE+W8hHolxdoRwHfK/s667zezwh1hkx6FFF+oYzetYgqK+Bg==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
+				"@opentelemetry/api-logs": "0.222.0",
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/resources": "2.11.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
+				"@opentelemetry/api": ">=1.4.0 <1.10.0"
 			}
 		},
-		"node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+		"node_modules/@opentelemetry/sdk-metrics": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.11.0.tgz",
+			"integrity": "sha512-7GXXcObyHyDUUSG+L+kJoquty01bzm7ivE7+SSgXXJcHuPzGviptxwARmI2c+bnnxjexGQbJnyNlN8HxBP/Y7A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/resources": "2.11.0"
+			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.9.0 <1.10.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-trace": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.11.0.tgz",
+			"integrity": "sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/resources": "2.11.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
+			},
+			"engines": {
+				"node": "^18.19.0 || >=20.6.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.11.0.tgz",
+			"integrity": "sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/resources": "1.30.1",
-				"@opentelemetry/semantic-conventions": "1.28.0"
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/resources": "2.11.0",
+				"@opentelemetry/sdk-trace": "2.11.0",
+				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"engines": {
-				"node": ">=14"
+				"@opentelemetry/api": ">=1.3.0 <1.10.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-node": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
-			"integrity": "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.11.0.tgz",
+			"integrity": "sha512-CuvCMJmZxswhNLlM2LfuLOW3h3fZujA4hsG4B+Sz4dX2zvaXO8Ng74cnDHWD64gLszTlhiG3c0iNUjj4g+0/sA==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@opentelemetry/context-async-hooks": "1.30.1",
-				"@opentelemetry/core": "1.30.1",
-				"@opentelemetry/propagator-b3": "1.30.1",
-				"@opentelemetry/propagator-jaeger": "1.30.1",
-				"@opentelemetry/sdk-trace-base": "1.30.1",
-				"semver": "^7.5.2"
+				"@opentelemetry/context-async-hooks": "2.11.0",
+				"@opentelemetry/core": "2.11.0",
+				"@opentelemetry/sdk-trace-base": "2.11.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": "^18.19.0 || >=20.6.0"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-			"dependencies": {
-				"@opentelemetry/semantic-conventions": "1.28.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": ">=1.0.0 <1.10.0"
-			}
-		},
-		"node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-			"integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.23.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
-			"integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
 			}
@@ -2408,63 +2030,6 @@
 			"funding": {
 				"url": "https://opencollective.com/pkgr"
 			}
-		},
-		"node_modules/@protobufjs/aspromise": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-		},
-		"node_modules/@protobufjs/base64": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-		},
-		"node_modules/@protobufjs/codegen": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-		},
-		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
-			}
-		},
-		"node_modules/@protobufjs/float": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-		},
-		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@protobufjs/path": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-		},
-		"node_modules/@protobufjs/pool": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-		},
-		"node_modules/@protobufjs/utf8": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.34.49",
@@ -2505,10 +2070,10 @@
 			}
 		},
 		"node_modules/@types/aws-lambda": {
-			"version": "8.10.149",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.149.tgz",
-			"integrity": "sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==",
-			"dev": true
+			"version": "8.10.163",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.163.tgz",
+			"integrity": "sha512-+4zuoEB3S8RIhimtOFT7zAEk2SbpwrKjjGl9CyYnQR6k08uynxfauIIB0pDU1ssr05F8oyGiETwpn+8eXZMqPw==",
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -2596,14 +2161,10 @@
 			"version": "20.17.30",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
 			"integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+			"dev": true,
 			"dependencies": {
 				"undici-types": "~6.19.2"
 			}
-		},
-		"node_modules/@types/shimmer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
@@ -2901,26 +2462,6 @@
 			"os": [
 				"win32"
 			]
-		},
-		"node_modules/acorn": {
-			"version": "8.14.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/acorn-import-assertions": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-			"deprecated": "package has been renamed to acorn-import-attributes",
-			"peerDependencies": {
-				"acorn": "^8"
-			}
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -3345,9 +2886,10 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+			"integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+			"license": "MIT"
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -3570,6 +3112,12 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+			"integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+			"license": "MIT"
+		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3784,6 +3332,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/forwarded-parse": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+			"integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+			"license": "MIT"
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -4032,14 +3586,17 @@
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-			"integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.4.0.tgz",
+			"integrity": "sha512-Xfjwfarhe+LGmoaof+sexeNo3sGRysb5x56WrZLwHtmqT0OilSKtVWkv0lrCcMgSKyKP9oBogBAisHZvtJH0aw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"acorn": "^8.8.2",
-				"acorn-import-assertions": "^1.9.0",
-				"cjs-module-lexer": "^1.2.2",
-				"module-details-from-path": "^1.0.3"
+				"cjs-module-lexer": "^2.2.0",
+				"es-module-lexer": "^2.2.0",
+				"module-details-from-path": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/import-local": {
@@ -4114,20 +3671,6 @@
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-			"dependencies": {
-				"hasown": "^2.0.2"
-			},
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -4892,13 +4435,6 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/jest-runtime/node_modules/cjs-module-lexer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/jest-runtime/node_modules/glob": {
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -5187,16 +4723,6 @@
 			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true
 		},
-		"node_modules/lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-		},
-		"node_modules/long": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
-			"integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng=="
-		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5296,9 +4822,10 @@
 			}
 		},
 		"node_modules/module-details-from-path": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-			"integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+			"integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+			"license": "MIT"
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
@@ -5501,11 +5028,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-		},
 		"node_modules/path-scurry": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -5607,30 +5129,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/protobufjs": {
-			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-			"integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
-			"hasInstallScript": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.2",
-				"@protobufjs/base64": "^1.1.2",
-				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
-				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.1",
-				"@protobufjs/path": "^1.1.2",
-				"@protobufjs/pool": "^1.1.0",
-				"@protobufjs/utf8": "^1.1.1",
-				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
 		"node_modules/punycode": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -5679,35 +5177,16 @@
 			}
 		},
 		"node_modules/require-in-the-middle": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-			"integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.5",
-				"module-details-from-path": "^1.0.3",
-				"resolve": "^1.22.8"
+				"module-details-from-path": "^1.0.3"
 			},
 			"engines": {
-				"node": ">=8.6.0"
-			}
-		},
-		"node_modules/resolve": {
-			"version": "1.22.10",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-			"dependencies": {
-				"is-core-module": "^2.16.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+				"node": ">=9.3.0 || >=8.10.0 <9.0.0"
 			}
 		},
 		"node_modules/resolve-cwd": {
@@ -5757,6 +5236,7 @@
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
 			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -5799,11 +5279,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/shimmer": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
@@ -5975,17 +5450,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/synckit": {
 			"version": "0.11.12",
 			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -6120,11 +5584,11 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
-			"peer": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6150,7 +5614,8 @@
 		"node_modules/undici-types": {
 			"version": "6.19.8",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"dev": true
 		},
 		"node_modules/unrs-resolver": {
 			"version": "1.11.1",

--- a/packages/otelbin-validation-image/package.json
+++ b/packages/otelbin-validation-image/package.json
@@ -10,7 +10,8 @@
 		"test": "jest",
 		"build": "npm run build:app && npm run build:wrapper",
 		"build:app": "esbuild src/index.ts --bundle --sourcemap --platform=node --target=es2020 --outfile=dist/index.js",
-		"build:wrapper": "esbuild src/lambda-wrapper.ts --bundle --sourcemap --platform=node --target=es2020 --outfile=dist/lambda-wrapper.js"
+		"build:wrapper": "esbuild src/lambda-wrapper.ts --bundle --sourcemap --platform=node --target=es2020 --outfile=dist/lambda-wrapper.js",
+		"typecheck": "tsc --noEmit"
 	},
 	"repository": {
 		"type": "git",
@@ -30,25 +31,27 @@
 		"@types/node": "^20.8.10",
 		"esbuild": "^0.28.1",
 		"jest": "^30.3.0",
-		"ts-jest": "^29.4.9"
+		"ts-jest": "^29.4.9",
+		"typescript": "^5.9.3"
 	},
 	"dependencies": {
 		"@expo/spawn-async": "^1.7.2",
+		"@opentelemetry/api": "^1.9.1",
+		"@opentelemetry/core": "^2.11.0",
+		"@opentelemetry/exporter-metrics-otlp-proto": "^0.222.0",
+		"@opentelemetry/exporter-trace-otlp-proto": "^0.222.0",
+		"@opentelemetry/instrumentation": "^0.222.0",
+		"@opentelemetry/instrumentation-aws-lambda": "^0.74.0",
+		"@opentelemetry/instrumentation-aws-sdk": "^0.77.0",
+		"@opentelemetry/instrumentation-dns": "^0.65.0",
+		"@opentelemetry/instrumentation-http": "^0.222.0",
+		"@opentelemetry/instrumentation-net": "^0.66.0",
+		"@opentelemetry/resource-detector-aws": "^2.22.0",
+		"@opentelemetry/resources": "^2.11.0",
+		"@opentelemetry/sdk-metrics": "^2.11.0",
+		"@opentelemetry/sdk-trace-base": "^2.11.0",
+		"@opentelemetry/sdk-trace-node": "^2.11.0",
 		"aws-lambda": "^1.0.7",
-		"js-yaml": "^4.3.1",
-		"@opentelemetry/api": "^1.7.0",
-		"@opentelemetry/exporter-trace-otlp-proto": "^0.50.0",
-		"@opentelemetry/exporter-metrics-otlp-proto": "^0.50.0",
-		"@opentelemetry/instrumentation": "^0.50.0",
-		"@opentelemetry/instrumentation-aws-lambda": "^0.40.0",
-		"@opentelemetry/instrumentation-aws-sdk": "^0.40.0",
-		"@opentelemetry/instrumentation-dns": "^0.35.0",
-		"@opentelemetry/instrumentation-http": "^0.35.0",
-		"@opentelemetry/instrumentation-net": "^0.35.0",
-		"@opentelemetry/resource-detector-aws": "^1.3.4",
-		"@opentelemetry/resources": "^1.18.1",
-		"@opentelemetry/sdk-metrics": "^1.18.1",
-		"@opentelemetry/sdk-trace-base": "^1.18.1",
-		"@opentelemetry/sdk-trace-node": "^1.18.1"
+		"js-yaml": "^4.3.1"
 	}
 }

--- a/packages/otelbin-validation-image/src/index.ts
+++ b/packages/otelbin-validation-image/src/index.ts
@@ -150,11 +150,16 @@ exports.validateAdot = async (otelcolRealPath: string, configPath: string, env: 
 	let stdout = "";
 	let stderr = "";
 
-	otelcol.stdout.on("data", (data) => {
+	/*
+	 * These three callback parameters are annotated explicitly because `spawn` is pulled in with
+	 * require() above, which makes it `any` and leaves the callbacks with no contextual type.
+	 * The annotations are what child_process would supply on its own under a static import.
+	 */
+	otelcol.stdout.on("data", (data: Buffer) => {
 		stdout += data.toString();
 	});
 
-	otelcol.stderr.on("data", (data) => {
+	otelcol.stderr.on("data", (data: Buffer) => {
 		/*
 		 * If the configuration is valid, the ADOT collector outputs to stderr:
 		 * `Everything is ready. Begin running and processing data.`
@@ -166,7 +171,7 @@ exports.validateAdot = async (otelcolRealPath: string, configPath: string, env: 
 		}
 	});
 
-	otelcol.on("close", (code) => {
+	otelcol.on("close", (code: number | null) => {
 		if (!isResolved) {
 			if (code===0) {
 				resolveFn();
@@ -254,6 +259,15 @@ function extractValidationErrorMessage(error: string): string {
 		[0];
 }
 
-exports.extractErrorPath = function extractErrorPath(errorMessage: string): string[] {
+/*
+ * Returns undefined when the message carries no `section::subsection:` prefix, which is what the
+ * optional chain below already did at runtime. The declared type used to claim `string[]`, and
+ * nothing objected because this file was never type checked. The caller passes the value straight
+ * to JSON.stringify, which drops an undefined key, and the reader in
+ * packages/otelbin/src/components/monaco-editor/otelCollectorConfigValidation.ts defaults a
+ * missing `path` to []. Returning [] here instead would put `"path":[]` on the wire, so the type
+ * is corrected rather than the behaviour.
+ */
+exports.extractErrorPath = function extractErrorPath(errorMessage: string): string[] | undefined {
 	return errorMessage.match(/^((?:[\w/]+(?:::)?)+):[^:]/)?.[1].split("::");
 }

--- a/packages/otelbin-validation-image/src/lambda-wrapper.test.ts
+++ b/packages/otelbin-validation-image/src/lambda-wrapper.test.ts
@@ -1,0 +1,34 @@
+import { trace } from "@opentelemetry/api";
+
+/*
+ * Importing the wrapper is the test. It exports nothing and does all of its work as import side
+ * effects, so every incompatibility this upgrade had to resolve (TracerProvider.addSpanProcessor,
+ * detectResourcesSync and getEnv all removed in SDK 2.0) throws a TypeError on that import. Until
+ * this file existed the only thing exercising those calls was a deployed Lambda, where the failure
+ * arrived as an HTTP 502 from API Gateway roughly half an hour after the merge.
+ */
+describe("lambda-wrapper", () => {
+	it("registers a tracer provider that records spans", () => {
+		expect(() => require("./lambda-wrapper")).not.toThrow();
+
+		/*
+		 * isRecording() is what separates a real SDK span from the API's no-op fallback. A provider
+		 * that is constructed but never registered, or registered without a span processor, still
+		 * hands back a NonRecordingSpan here, so this catches a silent registration failure that a
+		 * clean import would otherwise hide.
+		 */
+		const span = trace.getTracer("lambda-wrapper-test").startSpan("probe");
+		expect(span.isRecording()).toBe(true);
+		expect(span.spanContext().traceId).not.toBe("00000000000000000000000000000000");
+
+		/*
+		 * The detected resource has to reach the provider, not merely be computed. `process.runtime.name`
+		 * comes from processDetector, one of the three detectors handed to detectResources. `resource`
+		 * is on the SDK's span implementation rather than the API's Span interface, hence the cast.
+		 */
+		const { resource } = span as unknown as { resource: { attributes: Record<string, unknown> } };
+		expect(resource.attributes["process.runtime.name"]).toBe("nodejs");
+
+		span.end();
+	});
+});

--- a/packages/otelbin-validation-image/src/lambda-wrapper.ts
+++ b/packages/otelbin-validation-image/src/lambda-wrapper.ts
@@ -6,49 +6,51 @@
 // Changes from original:
 // - removed ability to overwrite config sections via globals
 // - removed some default instrumentations
+// - static imports instead of require(), so tsc checks these calls against the SDK's real types.
+//   Under require() every SDK symbol is `any`, which is how the removal of addSpanProcessor in
+//   SDK 2.0 reached a deployed Lambda with no build step objecting to it.
+// - the DNS, HTTP and Net instrumentations are listed in `instrumentations` rather than passed
+//   to AwsLambdaInstrumentation as its config. See the comment on that array.
 
-const { NodeTracerConfig, NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const {
-	BatchSpanProcessor,
-	ConsoleSpanExporter,
-	SDKRegistrationConfig,
-	SimpleSpanProcessor
-} = require("@opentelemetry/sdk-trace-base");
-const { registerInstrumentations } = require("@opentelemetry/instrumentation");
-const { awsLambdaDetector } = require("@opentelemetry/resource-detector-aws");
-const { detectResourcesSync, envDetector, processDetector } = require("@opentelemetry/resources");
-const { AwsInstrumentation } = require("@opentelemetry/instrumentation-aws-sdk");
-const {
-	AwsLambdaInstrumentation,
-} = require("@opentelemetry/instrumentation-aws-lambda");
-const { diag, DiagConsoleLogger, DiagLogLevel } = require("@opentelemetry/api");
-const { getEnv } = require("@opentelemetry/core");
-const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-proto");
-const { MeterProvider, MeterProviderOptions } = require("@opentelemetry/sdk-metrics");
-
-function defaultConfigureInstrumentations() {
-	// Use require statements for instrumentation to avoid having to have transitive dependencies on all the typescript
-	// definitions.
-	const { DnsInstrumentation } = require("@opentelemetry/instrumentation-dns");
-	const { HttpInstrumentation } = require("@opentelemetry/instrumentation-http");
-	const { NetInstrumentation } = require("@opentelemetry/instrumentation-net");
-	return [new DnsInstrumentation(),
-		new HttpInstrumentation(),
-		new NetInstrumentation()
-	];
-}
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { diagLogLevelFromString, getStringFromEnv } from '@opentelemetry/core';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { AwsLambdaInstrumentation } from '@opentelemetry/instrumentation-aws-lambda';
+import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk';
+import { DnsInstrumentation } from '@opentelemetry/instrumentation-dns';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { NetInstrumentation } from '@opentelemetry/instrumentation-net';
+import { awsLambdaDetector } from '@opentelemetry/resource-detector-aws';
+import { detectResources, envDetector, processDetector } from '@opentelemetry/resources';
+import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 
 console.log("Registering OpenTelemetry");
 
+/*
+ * The DNS, HTTP and Net instrumentations used to be built by a helper whose return value, an
+ * array, was passed to AwsLambdaInstrumentation as its config object. They were never part of
+ * this list. They still took effect, because constructing an instrumentation patches its target
+ * on its own, and spreading an array into the config yields only numeric keys, so that argument
+ * was equivalent to `{}`. Listing them here keeps exactly that behaviour while letting tsc check
+ * the call, which it cannot do when an array is passed where a config is expected.
+ */
 const instrumentations = [
 	new AwsInstrumentation({
 		suppressInternalInstrumentation: true
 	}),
-	new AwsLambdaInstrumentation(defaultConfigureInstrumentations())
+	new AwsLambdaInstrumentation({}),
+	new DnsInstrumentation(),
+	new HttpInstrumentation(),
+	new NetInstrumentation()
 ];
 
-// configure lambda logging
-const logLevel = getEnv().OTEL_LOG_LEVEL;
+// configure lambda logging.
+// SDK 2.0 removed getEnv(). diagLogLevelFromString is the supported way to read OTEL_LOG_LEVEL and
+// returns undefined for an unset or unrecognised value, which leaves diag at its default level.
+const logLevel = diagLogLevelFromString(getStringFromEnv("OTEL_LOG_LEVEL"));
 diag.setLogger(new DiagConsoleLogger(), logLevel);
 
 // Register instrumentations synchronously to ensure code is patched even before provider is ready.
@@ -56,39 +58,36 @@ registerInstrumentations({
 	instrumentations
 });
 
-async function initializeProvider() {
-	const resource = detectResourcesSync({
-		detectors: [awsLambdaDetector, envDetector, processDetector]
-	});
+// SDK 2.0 removed detectResourcesSync. detectResources is synchronous and returns a Resource.
+const resource = detectResources({
+	detectors: [awsLambdaDetector, envDetector, processDetector]
+});
 
-	let config: typeof NodeTracerConfig = {
-		resource
-	};
+// SDK 2.0 removed TracerProvider.addSpanProcessor(). Processors are constructor-only now, so the
+// list has to be complete before the provider is built instead of appended to afterwards.
+const spanProcessors: SpanProcessor[] = [
+	new BatchSpanProcessor(new OTLPTraceExporter())
+];
 
-	const tracerProvider = new NodeTracerProvider(config);
-		tracerProvider.addSpanProcessor(
-			new BatchSpanProcessor(new OTLPTraceExporter())
-		);
-	// logging for debug
-	if (logLevel===DiagLogLevel.DEBUG) {
-		tracerProvider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
-	}
-
-	let sdkRegistrationConfig: typeof SDKRegistrationConfig = {};
-	tracerProvider.register(sdkRegistrationConfig);
-
-	// Configure default meter provider (doesn't export metrics)
-	let meterConfig: typeof MeterProviderOptions = {
-		resource
-	};
-
-	const meterProvider = new MeterProvider(meterConfig);
-	// Re-register instrumentation with initialized provider. Patched code will see the update.
-	registerInstrumentations({
-		instrumentations,
-		tracerProvider,
-		meterProvider
-	});
+// logging for debug
+if (logLevel === DiagLogLevel.DEBUG) {
+	spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 }
 
-initializeProvider();
+const tracerProvider = new NodeTracerProvider({
+	resource,
+	spanProcessors
+});
+tracerProvider.register();
+
+// Configure default meter provider (doesn't export metrics)
+const meterProvider = new MeterProvider({
+	resource
+});
+
+// Re-register instrumentation with initialized provider. Patched code will see the update.
+registerInstrumentations({
+	instrumentations,
+	tracerProvider,
+	meterProvider
+});

--- a/packages/otelbin-validation-image/tsconfig.json
+++ b/packages/otelbin-validation-image/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  // This package had no tsconfig.json and no type-checking step. esbuild bundles without type
+  // checking, so `npm run build` reported success on code that could not run: the SDK 2.0
+  // removal of TracerProvider.addSpanProcessor() reached a deployed Lambda and surfaced only as
+  // HTTP 502 from API Gateway. `npm run typecheck` closes that gap.
+  //
+  // "target" matches the --target=es2020 the esbuild scripts emit, so the compiler and the
+  // bundler agree on what syntax is available.
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "ES2020"
+    ],
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
Closes #691.

## Why

`packages/otelbin-validation-image` was pinned to the OpenTelemetry JS 1.x/0.5x line. The packages have to move in lockstep: the stable ones version at 1.x and 2.x, the experimental exporters and instrumentations version at 0.x, and a given experimental release only works against one stable major.

Moving one package across that boundary is what broke `main`. `@opentelemetry/sdk-trace-node` went to 2.x on its own, and 2.x removed `TracerProvider.addSpanProcessor()`, which `src/lambda-wrapper.ts` called. Nothing objected: the wrapper loaded the SDK through `require()`, so every symbol was `any`, and esbuild bundles without type checking. The failure surfaced as an HTTP 502 from API Gateway after deploy.

#701 stops the single-package bump from happening again. This PR does the upgrade itself and closes the two gaps that let the breakage through undetected.

## The upgrade

The whole set moves at once: stable at `^2.11.0`, `@opentelemetry/api` at `^1.9.1` (the API stays on 1.x), `resource-detector-aws` at `^2.22.0`, and the experimental packages at their matching `0.x`.

Three removals in SDK 2.0 needed adapting in `src/lambda-wrapper.ts`:

- **`TracerProvider.addSpanProcessor()` is gone.** Span processors are constructor-only now, so the list is complete before `NodeTracerProvider` is built rather than appended to afterwards.
- **`detectResourcesSync` is gone.** `detectResources` is synchronous now and replaces it directly.
- **`getEnv()` is gone.** `OTEL_LOG_LEVEL` is read with `getStringFromEnv` and converted by `diagLogLevelFromString`, which returns `undefined` for an unset or unrecognized value and so leaves `diag` at its default level.

## Two behavior-preserving cleanups worth reviewing

**`require()` becomes static imports.** This is the change that makes the rest checkable. It also flips how esbuild classifies the file, so I verified the output rather than assuming: `dist/lambda-wrapper.js` still begins `"use strict";`, contains no top-level `import`/`export`, and `node -e 'require("./dist/lambda-wrapper.js")'` loads it and prints `Registering OpenTelemetry`. That matters because the Dockerfile loads it as `NODE_OPTIONS="--require /usr/app/src/lambda-wrapper.js"`. `src/index.ts` keeps its `require()` calls deliberately: it relies on `exports.handler`, and value-level `import` there would make esbuild treat it as ESM and break that.

**The DNS, HTTP and Net instrumentations move into the registered `instrumentations` array.** They were previously built by a helper whose return value, an array, was passed to `AwsLambdaInstrumentation` as its *config object*. Spreading an array into a config yields numeric keys only, so that argument was equivalent to `{}`. They still took effect, because constructing an instrumentation patches its target on its own. Listing them keeps exactly that behavior while letting `tsc` check the call, which it cannot do when an array is passed where a config is expected.

## Closing the detection gap

- **`tsconfig.json` plus a `typecheck` script, wired into `otelbin-validation-image-verify`.** This package had neither. esbuild strips types without checking them, so nothing in CI ever compared the source against its dependencies' types.
- **`src/lambda-wrapper.test.ts`.** The wrapper exports nothing and does all its work as import side effects, so importing it exercises every call above. The test also asserts the provider is registered and records spans, and that the detected resource reaches it.

I checked the test is not vacuous. Reintroducing the `addSpanProcessor` call fails the suite with `"tracerProvider.addSpanProcessor is not a function"`, and removing the injection returns it to green.

## Two previously phantom dependencies, now declared

- `@opentelemetry/core`, which `lambda-wrapper.ts` now imports directly for `getStringFromEnv` and `diagLogLevelFromString`.
- `typescript`, which only reached the package transitively through `ts-jest`.

## Four type errors the new typecheck surfaced in `src/index.ts`

Three are callback parameters left untyped because `spawn` arrives via `require()`, so they get the annotations `child_process` would have supplied on its own.

The fourth is a real latent bug. `extractErrorPath` is declared to return `string[]`, but its body ends in `errorMessage.match(...)?.[1].split("::")`, which returns `undefined` when the message carries no `section::subsection:` prefix. I corrected the type rather than the behavior: the caller passes the value to `JSON.stringify`, where an `undefined` key is dropped, and the reader in `packages/otelbin/src/components/monaco-editor/otelCollectorConfigValidation.ts:55` already defaults a missing `path` to `[]`. Returning `[]` here instead would put `"path":[]` on the wire.

## Verification

Run against a clean `npm ci --ignore-scripts` tree on Node 22, which is what CI does:

| Command | Result |
| --- | --- |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |
| `npm run test` | 2 suites, 6 tests, exit 0 |
| `require("./dist/lambda-wrapper.js")` | loads, prints `Registering OpenTelemetry` |
| `require("./dist/index.js").handler` | `function` |

The runtime behavior of the deployed image is not covered by any of this. The integration tests in `run-itests` exercise the validation endpoint end to end, so a wrapper that loads but traces nothing would still pass. I would want one deploy to a test environment watched before this merges.

## Note for a follow-up, not addressed here

`Dockerfile:21-22` copies only `package.json` and runs `npm install`, without `package-lock.json`. The image build therefore resolves the `^` ranges fresh every time, so the deployed dependency tree is not the one this PR's lockfile pins and two builds of the same commit can differ. Worth fixing separately.

## Base

Branch is one commit behind `main` (#701 landed after I pushed, and touches only `.github/dependabot.yml`, which this PR does not). Needs "Update branch" before merge.
