### PR TITLE
ci: federate into AWS via GitHub OIDC instead of static access keys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,10 +19,11 @@ on:
     branches:
       - 'main'
 
-# Only `contents: read` is needed. `actions/checkout` reads the repo, and the AWS steps
-# authenticate with static access keys rather than OIDC, so nothing ever requested an OIDC
-# token. Granting `id-token: write` put a requestable token in every job's environment,
-# including the `pull_request_target` jobs that install dependency versions the PR proposes.
+# Default to `contents: read` only. `actions/checkout` reads the repo, and most jobs never
+# authenticate to AWS. The three jobs that do now federate via OIDC and so need
+# `id-token: write`, but that is granted per job rather than here: a workflow-level grant would
+# put a requestable OIDC token in every job's environment, including the `pull_request_target`
+# jobs that install the dependency versions a PR proposes.
 permissions:
   contents: read
 
@@ -148,6 +149,11 @@ jobs:
   prep-itests:
     name: Deploy validation backend
     needs: ['otelbin-verify', 'otelbin-validation-image-verify', 'otelbin-validation-verify']
+    permissions:
+      # Needed to mint the OIDC token this job federates into AWS with. Scoped to this job
+      # rather than the whole workflow; see the note on the workflow-level `permissions` above.
+      id-token: write
+      contents: read
     # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
     # target account. A ref-based claim cannot do this: a dependabot
     # `pull_request_target` run presents the base ref (`refs/heads/main`), which is
@@ -294,6 +300,11 @@ jobs:
   run-itests:
     name: Validation tests
     needs: ['prep-itests']
+    permissions:
+      # Needed to mint the OIDC token this job federates into AWS with. Scoped to this job
+      # rather than the whole workflow; see the note on the workflow-level `permissions` above.
+      id-token: write
+      contents: read
     # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
     # target account. A ref-based claim cannot do this: a dependabot
     # `pull_request_target` run presents the base ref (`refs/heads/main`), which is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,10 @@ on:
     branches:
       - 'main'
 
-# Default to `contents: read` only. `actions/checkout` reads the repo, and most jobs never
-# authenticate to AWS. The three jobs that do now federate via OIDC and so need
-# `id-token: write`, but that is granted per job rather than here: a workflow-level grant would
-# put a requestable OIDC token in every job's environment, including the `pull_request_target`
-# jobs that install the dependency versions a PR proposes.
+# Baseline for every job: read the repository, nothing else. The jobs that authenticate to
+# AWS grant themselves `id-token: write` individually. Granting it here would instead put a
+# requestable OIDC token in the environment of every job, including the `pull_request_target`
+# jobs, which install the dependency versions a pull request proposes.
 permissions:
   contents: read
 
@@ -150,16 +149,19 @@ jobs:
     name: Deploy validation backend
     needs: ['otelbin-verify', 'otelbin-validation-image-verify', 'otelbin-validation-verify']
     permissions:
-      # Needed to mint the OIDC token this job federates into AWS with. Scoped to this job
-      # rather than the whole workflow; see the note on the workflow-level `permissions` above.
+      # Mints the OIDC token that `Configure AWS credentials` exchanges for AWS credentials.
+      # Scoped to this job; see the workflow-level `permissions` above.
       id-token: write
       contents: read
-    # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
-    # target account. A ref-based claim cannot do this: a dependabot
-    # `pull_request_target` run presents the base ref (`refs/heads/main`), which is
-    # byte-identical to the claim for a push to main, i.e. the production deploy.
-    # The condition matches `test_env_name.sh`, which yields `main` only when the
-    # ref name is `main`; tag pushes and PRs all deploy to the development account.
+    # Chooses which AWS account this job federates into. The environment name becomes the
+    # `sub` claim of the OIDC token (`repo:dash0hq/otelbin:environment:<name>`), and the role
+    # in each account trusts exactly one name.
+    #
+    # The claim has to key off the environment rather than the ref: under
+    # `pull_request_target` the ref claim is the base ref, `refs/heads/main`, which is
+    # indistinguishable from a push to main. The condition mirrors `test_env_name.sh`, which
+    # yields `main` only for a ref named `main`, so tag pushes and pull requests go to
+    # development.
     environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
     runs-on: 8core_32gb
     # The CDK deploy runs a median of ~25 minutes with a p90 of ~29, so a 30 minute limit killed
@@ -224,8 +226,8 @@ jobs:
           OTELBIN_AUTOMATION_ROLE_ARN_PROD: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_PROD}}
           OTELBIN_AUTOMATION_ACCOUNT_DEV: ${{secrets.OTELBIN_AUTOMATION_ACCOUNT_DEV}}
           OTELBIN_AUTOMATION_ROLE_ARN_DEV: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_DEV}}
-        # No access keys here any more: the role is assumed via GitHub OIDC, so only
-        # the account ID and the role ARN need selecting.
+        # Resolves the account ID that CDK deploys into and the ARN of the role to assume.
+        # The credentials themselves come from OIDC, so nothing secret is selected here.
         # language=bash
         run: |
           if [ "${TEST_ENVIRONMENT_NAME}" == 'main' ]; then
@@ -301,16 +303,19 @@ jobs:
     name: Validation tests
     needs: ['prep-itests']
     permissions:
-      # Needed to mint the OIDC token this job federates into AWS with. Scoped to this job
-      # rather than the whole workflow; see the note on the workflow-level `permissions` above.
+      # Mints the OIDC token that `Configure AWS credentials` exchanges for AWS credentials.
+      # Scoped to this job; see the workflow-level `permissions` above.
       id-token: write
       contents: read
-    # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
-    # target account. A ref-based claim cannot do this: a dependabot
-    # `pull_request_target` run presents the base ref (`refs/heads/main`), which is
-    # byte-identical to the claim for a push to main, i.e. the production deploy.
-    # The condition matches `test_env_name.sh`, which yields `main` only when the
-    # ref name is `main`; tag pushes and PRs all deploy to the development account.
+    # Chooses which AWS account this job federates into. The environment name becomes the
+    # `sub` claim of the OIDC token (`repo:dash0hq/otelbin:environment:<name>`), and the role
+    # in each account trusts exactly one name.
+    #
+    # The claim has to key off the environment rather than the ref: under
+    # `pull_request_target` the ref claim is the base ref, `refs/heads/main`, which is
+    # indistinguishable from a push to main. The condition mirrors `test_env_name.sh`, which
+    # yields `main` only for a ref named `main`, so tag pushes and pull requests go to
+    # development.
     environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
     # See prep-itests above for why this condition exists; run-itests needs the same gating
     # since it depends on prep-itests's outputs and shares the same credential requirements.
@@ -351,7 +356,7 @@ jobs:
           TEST_ENVIRONMENT_NAME: ${{ needs.prep-itests.outputs.test_env_name }}
           OTELBIN_AUTOMATION_ROLE_ARN_PROD: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_PROD}}
           OTELBIN_AUTOMATION_ROLE_ARN_DEV: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_DEV}}
-        # No access keys here any more: the role is assumed via GitHub OIDC.
+        # Resolves the ARN of the role to assume; the credentials come from OIDC.
         # language=bash
         run: |
           if [ "${TEST_ENVIRONMENT_NAME}" == 'main' ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,14 +155,16 @@ jobs:
       contents: read
     # Chooses which AWS account this job federates into. The environment name becomes the
     # `sub` claim of the OIDC token (`repo:dash0hq/otelbin:environment:<name>`), and the role
-    # in each account trusts exactly one name.
+    # in each account trusts exactly one name. The `-Backend` names pair with Vercel's
+    # `Preview` and `Production` environments, which cover the frontend deploys in this same
+    # repository; case is significant, since the role matches the claim with `StringLike`.
     #
     # The claim has to key off the environment rather than the ref: under
     # `pull_request_target` the ref claim is the base ref, `refs/heads/main`, which is
     # indistinguishable from a push to main. The condition mirrors `test_env_name.sh`, which
-    # yields `main` only for a ref named `main`, so tag pushes and pull requests go to
-    # development.
-    environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
+    # yields `main` only for a ref named `main`, so tag pushes and pull requests land on
+    # `Preview-Backend`.
+    environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'Production-Backend' || 'Preview-Backend' }}
     runs-on: 8core_32gb
     # The CDK deploy runs a median of ~25 minutes with a p90 of ~29, so a 30 minute limit killed
     # roughly 8% of runs. A killed job also leaves the per-branch CloudFormation stack mid-deploy,
@@ -309,14 +311,16 @@ jobs:
       contents: read
     # Chooses which AWS account this job federates into. The environment name becomes the
     # `sub` claim of the OIDC token (`repo:dash0hq/otelbin:environment:<name>`), and the role
-    # in each account trusts exactly one name.
+    # in each account trusts exactly one name. The `-Backend` names pair with Vercel's
+    # `Preview` and `Production` environments, which cover the frontend deploys in this same
+    # repository; case is significant, since the role matches the claim with `StringLike`.
     #
     # The claim has to key off the environment rather than the ref: under
     # `pull_request_target` the ref claim is the base ref, `refs/heads/main`, which is
     # indistinguishable from a push to main. The condition mirrors `test_env_name.sh`, which
-    # yields `main` only for a ref named `main`, so tag pushes and pull requests go to
-    # development.
-    environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
+    # yields `main` only for a ref named `main`, so tag pushes and pull requests land on
+    # `Preview-Backend`.
+    environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'Production-Backend' || 'Preview-Backend' }}
     # See prep-itests above for why this condition exists; run-itests needs the same gating
     # since it depends on prep-itests's outputs and shares the same credential requirements.
     if: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,13 @@ jobs:
   prep-itests:
     name: Deploy validation backend
     needs: ['otelbin-verify', 'otelbin-validation-image-verify', 'otelbin-validation-verify']
+    # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
+    # target account. A ref-based claim cannot do this: a dependabot
+    # `pull_request_target` run presents the base ref (`refs/heads/main`), which is
+    # byte-identical to the claim for a push to main, i.e. the production deploy.
+    # The condition matches `test_env_name.sh`, which yields `main` only when the
+    # ref name is `main`; tag pushes and PRs all deploy to the development account.
+    environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
     runs-on: 8core_32gb
     # The CDK deploy runs a median of ~25 minutes with a p90 of ~29, so a 30 minute limit killed
     # roughly 8% of runs. A killed job also leaves the per-branch CloudFormation stack mid-deploy,
@@ -202,38 +209,30 @@ jobs:
         run: |
           echo "test_env_name=$(./.github/workflows/scripts/test_env_name.sh)" >> "$GITHUB_OUTPUT" || exit 1
 
-      - name: Select credentials
+      - name: Select target account
         id: select_credentials
         shell: bash
         env:
           TEST_ENVIRONMENT_NAME: ${{ steps.get_test_env_name.outputs.test_env_name }}
           OTELBIN_AUTOMATION_ACCOUNT_PROD: ${{secrets.OTELBIN_AUTOMATION_ACCOUNT_PROD}}
-          OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD: ${{secrets.OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD}}
-          OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD: ${{secrets.OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD}}
           OTELBIN_AUTOMATION_ROLE_ARN_PROD: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_PROD}}
           OTELBIN_AUTOMATION_ACCOUNT_DEV: ${{secrets.OTELBIN_AUTOMATION_ACCOUNT_DEV}}
-          OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV: ${{secrets.OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV}}
-          OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV: ${{secrets.OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV}}
           OTELBIN_AUTOMATION_ROLE_ARN_DEV: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_DEV}}
+        # No access keys here any more: the role is assumed via GitHub OIDC, so only
+        # the account ID and the role ARN need selecting.
         # language=bash
         run: |
           if [ "${TEST_ENVIRONMENT_NAME}" == 'main' ]; then
             echo "aws_account=${OTELBIN_AUTOMATION_ACCOUNT_PROD}" >> "${GITHUB_OUTPUT}"
-            echo "aws_access_key=${OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD}" >> "${GITHUB_OUTPUT}"
-            echo "aws_secret_access_key=${OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD}" >> "${GITHUB_OUTPUT}"
             echo "role_arn=${OTELBIN_AUTOMATION_ROLE_ARN_PROD}" >> "${GITHUB_OUTPUT}"
           else
             echo "aws_account=${OTELBIN_AUTOMATION_ACCOUNT_DEV}" >> "${GITHUB_OUTPUT}"
-            echo "aws_access_key=${OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV}" >> "${GITHUB_OUTPUT}"
-            echo "aws_secret_access_key=${OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV}" >> "${GITHUB_OUTPUT}"
             echo "role_arn=${OTELBIN_AUTOMATION_ROLE_ARN_DEV}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          aws-access-key-id: ${{ steps.select_credentials.outputs.aws_access_key }}
-          aws-secret-access-key: ${{ steps.select_credentials.outputs.aws_secret_access_key }}
           aws-region: 'us-east-2'
           mask-aws-account-id: true
           role-to-assume: ${{ steps.select_credentials.outputs.role_arn }}
@@ -295,6 +294,13 @@ jobs:
   run-itests:
     name: Validation tests
     needs: ['prep-itests']
+    # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
+    # target account. A ref-based claim cannot do this: a dependabot
+    # `pull_request_target` run presents the base ref (`refs/heads/main`), which is
+    # byte-identical to the claim for a push to main, i.e. the production deploy.
+    # The condition matches `test_env_name.sh`, which yields `main` only when the
+    # ref name is `main`; tag pushes and PRs all deploy to the development account.
+    environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
     # See prep-itests above for why this condition exists; run-itests needs the same gating
     # since it depends on prep-itests's outputs and shares the same credential requirements.
     if: |
@@ -327,34 +333,25 @@ jobs:
         run: |
           npm ci --ignore-scripts
 
-      - name: Select credentials
+      - name: Select target account
         id: select_credentials
         shell: bash
         env:
           TEST_ENVIRONMENT_NAME: ${{ needs.prep-itests.outputs.test_env_name }}
-          OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD: ${{secrets.OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD}}
-          OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD: ${{secrets.OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD}}
           OTELBIN_AUTOMATION_ROLE_ARN_PROD: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_PROD}}
-          OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV: ${{secrets.OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV}}
-          OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV: ${{secrets.OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV}}
           OTELBIN_AUTOMATION_ROLE_ARN_DEV: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_DEV}}
+        # No access keys here any more: the role is assumed via GitHub OIDC.
         # language=bash
         run: |
           if [ "${TEST_ENVIRONMENT_NAME}" == 'main' ]; then
-            echo "aws_access_key=${OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD}" >> "${GITHUB_OUTPUT}"
-            echo "aws_secret_access_key=${OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD}" >> "${GITHUB_OUTPUT}"
             echo "role_arn=${OTELBIN_AUTOMATION_ROLE_ARN_PROD}" >> "${GITHUB_OUTPUT}"
           else
-            echo "aws_access_key=${OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV}" >> "${GITHUB_OUTPUT}"
-            echo "aws_secret_access_key=${OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV}" >> "${GITHUB_OUTPUT}"
             echo "role_arn=${OTELBIN_AUTOMATION_ROLE_ARN_DEV}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          aws-access-key-id: ${{ steps.select_credentials.outputs.aws_access_key }}
-          aws-secret-access-key: ${{ steps.select_credentials.outputs.aws_secret_access_key }}
           aws-region: 'us-east-2'
           mask-aws-account-id: true
           role-to-assume: ${{ steps.select_credentials.outputs.role_arn }}

--- a/.github/workflows/clean-up-test-env.yaml
+++ b/.github/workflows/clean-up-test-env.yaml
@@ -6,9 +6,8 @@ on:
     types: [ closed ]
   workflow_dispatch:
 
-# Default to `contents: read`; the one job that authenticates to AWS grants itself
-# `id-token: write` below. Same reasoning as `ci.yaml`: a workflow-level OIDC grant is
-# wider than it needs to be.
+# Baseline for every job: read the repository, nothing else. The one job that authenticates
+# to AWS grants itself `id-token: write` below, so no OIDC token is requestable anywhere else.
 permissions:
   contents: read
 
@@ -32,13 +31,12 @@ jobs:
   cleanup_test_env:
     name: Clean up test environment ${{ github.ref }}
     permissions:
-      # Needed to mint the OIDC token this job federates into AWS with. This workflow
-      # previously authenticated with static access keys and declared no permissions at all.
+      # Mints the OIDC token that `Configure AWS credentials` exchanges for AWS credentials.
       id-token: write
       contents: read
-    # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
-    # target account. See the same block in `ci.yaml`. This workflow only ever
-    # reaches production via a manual dispatch on main; every `pull_request` close
+    # Chooses which AWS account this job federates into; see the equivalent block in
+    # `ci.yaml` for how the environment name reaches the OIDC `sub` claim. Production is
+    # reachable only by dispatching this workflow on main; closing a pull request always
     # tears down a development test environment.
     environment: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
     runs-on: ubuntu-latest
@@ -80,8 +78,8 @@ jobs:
           OTELBIN_AUTOMATION_ROLE_ARN_PROD: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_PROD}}
           OTELBIN_AUTOMATION_ACCOUNT_DEV: ${{secrets.OTELBIN_AUTOMATION_ACCOUNT_DEV}}
           OTELBIN_AUTOMATION_ROLE_ARN_DEV: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_DEV}}
-        # No access keys here any more: the role is assumed via GitHub OIDC, so only
-        # the account ID and the role ARN need selecting.
+        # Resolves the account ID that CDK targets and the ARN of the role to assume.
+        # The credentials themselves come from OIDC, so nothing secret is selected here.
         # language=bash
         run: |
           if [ "${TEST_ENVIRONMENT_NAME}" == 'main' ]; then

--- a/.github/workflows/clean-up-test-env.yaml
+++ b/.github/workflows/clean-up-test-env.yaml
@@ -35,10 +35,10 @@ jobs:
       id-token: write
       contents: read
     # Chooses which AWS account this job federates into; see the equivalent block in
-    # `ci.yaml` for how the environment name reaches the OIDC `sub` claim. Production is
-    # reachable only by dispatching this workflow on main; closing a pull request always
-    # tears down a development test environment.
-    environment: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
+    # `ci.yaml` for how the environment name reaches the OIDC `sub` claim.
+    # `Production-Backend` is reachable only by dispatching this workflow on main; closing a
+    # pull request always tears down a `Preview-Backend` test environment.
+    environment: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') && 'Production-Backend' || 'Preview-Backend' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/clean-up-test-env.yaml
+++ b/.github/workflows/clean-up-test-env.yaml
@@ -6,6 +6,13 @@ on:
     types: [ closed ]
   workflow_dispatch:
 
+# Required so the job can mint an OIDC token and federate into AWS. `ci.yaml`
+# already declares this; this workflow did not, because it previously
+# authenticated with static access keys.
+permissions:
+  id-token: write
+  contents: read
+
 # Byte-for-byte the same group key as `ci.yaml`, so a CI deploy and this teardown
 # for the same PR are serialized: both resolve `github.head_ref` to the PR's branch
 # name. This also keeps two teardowns for the same PR (e.g. closed -> reopened ->
@@ -25,6 +32,11 @@ concurrency:
 jobs:
   cleanup_test_env:
     name: Clean up test environment ${{ github.ref }}
+    # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
+    # target account. See the same block in `ci.yaml`. This workflow only ever
+    # reaches production via a manual dispatch on main; every `pull_request` close
+    # tears down a development test environment.
+    environment: ${{ (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') && 'otelbin-production' || 'otelbin-development' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -55,38 +67,30 @@ jobs:
         run: |
           echo "test_env_name=$(./.github/workflows/scripts/test_env_name.sh)" >> "$GITHUB_OUTPUT" || exit 1
 
-      - name: Select credentials
+      - name: Select target account
         id: select_credentials
         shell: bash
         env:
           TEST_ENVIRONMENT_NAME: ${{ steps.get_test_env_name.outputs.test_env_name }}
           OTELBIN_AUTOMATION_ACCOUNT_PROD: ${{secrets.OTELBIN_AUTOMATION_ACCOUNT_PROD}}
-          OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD: ${{secrets.OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD}}
-          OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD: ${{secrets.OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD}}
           OTELBIN_AUTOMATION_ROLE_ARN_PROD: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_PROD}}
           OTELBIN_AUTOMATION_ACCOUNT_DEV: ${{secrets.OTELBIN_AUTOMATION_ACCOUNT_DEV}}
-          OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV: ${{secrets.OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV}}
-          OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV: ${{secrets.OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV}}
           OTELBIN_AUTOMATION_ROLE_ARN_DEV: ${{secrets.OTELBIN_AUTOMATION_ROLE_ARN_DEV}}
+        # No access keys here any more: the role is assumed via GitHub OIDC, so only
+        # the account ID and the role ARN need selecting.
         # language=bash
         run: |
           if [ "${TEST_ENVIRONMENT_NAME}" == 'main' ]; then
             echo "aws_account=${OTELBIN_AUTOMATION_ACCOUNT_PROD}" >> "${GITHUB_OUTPUT}"
-            echo "aws_access_key=${OTELBIN_AUTOMATION_ACCESS_KEY_ID_PROD}" >> "${GITHUB_OUTPUT}"
-            echo "aws_secret_access_key=${OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_PROD}" >> "${GITHUB_OUTPUT}"
             echo "role_arn=${OTELBIN_AUTOMATION_ROLE_ARN_PROD}" >> "${GITHUB_OUTPUT}"
           else
             echo "aws_account=${OTELBIN_AUTOMATION_ACCOUNT_DEV}" >> "${GITHUB_OUTPUT}"
-            echo "aws_access_key=${OTELBIN_AUTOMATION_ACCESS_KEY_ID_DEV}" >> "${GITHUB_OUTPUT}"
-            echo "aws_secret_access_key=${OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_DEV}" >> "${GITHUB_OUTPUT}"
             echo "role_arn=${OTELBIN_AUTOMATION_ROLE_ARN_DEV}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          aws-access-key-id: ${{ steps.select_credentials.outputs.aws_access_key }}
-          aws-secret-access-key: ${{ steps.select_credentials.outputs.aws_secret_access_key }}
           aws-region: 'us-east-2'
           mask-aws-account-id: true
           role-to-assume: ${{ steps.select_credentials.outputs.role_arn }}

--- a/.github/workflows/clean-up-test-env.yaml
+++ b/.github/workflows/clean-up-test-env.yaml
@@ -6,11 +6,10 @@ on:
     types: [ closed ]
   workflow_dispatch:
 
-# Required so the job can mint an OIDC token and federate into AWS. `ci.yaml`
-# already declares this; this workflow did not, because it previously
-# authenticated with static access keys.
+# Default to `contents: read`; the one job that authenticates to AWS grants itself
+# `id-token: write` below. Same reasoning as `ci.yaml`: a workflow-level OIDC grant is
+# wider than it needs to be.
 permissions:
-  id-token: write
   contents: read
 
 # Byte-for-byte the same group key as `ci.yaml`, so a CI deploy and this teardown
@@ -32,6 +31,11 @@ concurrency:
 jobs:
   cleanup_test_env:
     name: Clean up test environment ${{ github.ref }}
+    permissions:
+      # Needed to mint the OIDC token this job federates into AWS with. This workflow
+      # previously authenticated with static access keys and declared no permissions at all.
+      id-token: write
+      contents: read
     # Binds the job to a GitHub environment so the OIDC `sub` claim identifies the
     # target account. See the same block in `ci.yaml`. This workflow only ever
     # reaches production via a manual dispatch on main; every `pull_request` close


### PR DESCRIPTION
Cutover half of the work to stop using long-lived AWS access keys in this repository's CI. The AWS-side roles already exist and have been applied in our infrastructure repository.

## What changes

The three credentialed jobs — `prep-itests` and `run-itests` in `ci.yaml`, `cleanup_test_env` in `clean-up-test-env.yaml` — stop using long-lived AWS access keys and federate via GitHub OIDC instead.

Mostly subtractive. The workflows already passed `role-to-assume`; the static keys were only there to bootstrap it. So the diff removes the `aws-access-key-id` and `aws-secret-access-key` inputs and the secret plumbing that fed them, and leaves `role-to-assume` doing the whole handshake.

The role ARNs stay in the existing `OTELBIN_AUTOMATION_ROLE_ARN_DEV` / `_PROD` secrets, which now point at the new roles. Nothing about the target accounts is hardcoded in the workflow files.

## Why the jobs bind to a GitHub environment

This is the part worth reviewing. A dependabot run goes through `pull_request_target`, whose OIDC `sub` claim is the **base** ref, `repo:dash0hq/otelbin:ref:refs/heads/main`. That is identical to the claim presented by a push to main, which is the production deploy. A ref-scoped trust policy cannot tell the two apart.

Binding each job to a GitHub environment moves the claim to `repo:dash0hq/otelbin:environment:<name>`, which the roles match on instead. The selecting expression mirrors `test_env_name.sh`, which resolves to `main` only when the ref name is `main`:

```yaml
environment: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'Production-Backend' || 'Preview-Backend' }}
```

Tag pushes and every PR therefore land on `Preview-Backend`, matching today's behaviour.

The two environments are named to pair with Vercel's `Preview` and `Production`, which cover the frontend deploys in this repository, so it is clear which system an environment belongs to. The casing is load-bearing: the token carries the name verbatim and the role matches it with `StringLike`.

## `id-token: write` is granted per job, not workflow-wide

#699 removed the workflow-level `id-token: write` from `ci.yaml` on purpose: a blanket grant puts a requestable OIDC token in every job's environment, including the `pull_request_target` jobs that install the dependency versions a PR proposes.

Restoring it at workflow level would undo that. Instead the three jobs that federate grant it themselves, and everything else stays at `contents: read`. `clean-up-test-env.yaml` follows the same shape, so both files read alike — it previously declared no `permissions` at all, which is why its job could not mint a token.

The first commit here missed this and failed at `Configure AWS credentials` with "Could not load credentials from any providers"; the second commit is the fix.

## Heads-up: this generates a lot of deployment records

GitHub creates one deployment record per *job* that declares `environment:`, and matrix jobs count individually. `run-itests` is a 107-entry matrix, so each CI run writes **108 deployments** to `Preview-Backend` — 1 from `prep-itests` and 107 from `run-itests`. They all reach `success` and nothing is left dangling, but the environment's deployment history is noisy.

This is inherent to needing credentials inside the matrix. `run-itests` reads the validation API key from SSM, so it needs the OIDC token, so it needs the environment binding. The alternatives are worse: passing the key through job outputs would push a credential through the workflow, which is what this repo deliberately stopped doing for the Dash0 token; and a ref-scoped role for `run-itests` reintroduces the `pull_request_target` collision described above.

> [!IMPORTANT]
> **Do not add a required-reviewer or wait-timer protection rule to `Preview-Backend`.** Each of the 107 matrix jobs would request approval independently and CI would become unusable. Nothing is broken today — `Preview-Backend` has no protection rules — but the hazard is worth knowing about before anyone reaches for one. `Production-Backend` does carry a required-reviewer rule, which is a deliberate gate on the production deploy rather than an accident, and it sees one job rather than the matrix on a push to main.

If the volume bothers us enough, splitting the API-key read out of the matrix is a possible follow-up, with its own design discussion.

## Test plan

- **CI is green on `924abd3c`.** All 107 `Validation tests` matrix jobs, `Deploy validation backend`, the three verify jobs, `CI passed`, CLA and Aikido all pass. `Configure AWS credentials` succeeded against the development role, so the OIDC handshake works end to end. That run predates the environment rename, so it needs repeating on `Preview-Backend` before this merges.
- YAML parses. `actionlint` goes from 16 findings on the base to 10, all pre-existing (the unknown `8core_32gb` runner label, plus shellcheck warnings on untouched scripts). The 6 that disappear were warnings on the deleted key-plumbing lines. No new findings.
- The roles were verified against IAM after creation: providers registered, trust policies scoped to the two environment `sub` claims, permissions matching what CI actually exercises over a 30-day window.
- **Not yet exercised:** the other three paths. A dependabot PR, a push to main, and a PR close for the teardown job. The dependabot path is the one the environment binding exists to protect, so it needs confirming that it lands on the development role and not production. The push-to-main path is only reachable after merge.

## Follow-up

Once this is merged and verified, the four `OTELBIN_AUTOMATION_ACCESS_KEY_ID_*` / `OTELBIN_AUTOMATION_SECRET_ACCESS_KEY_*` secrets can be deleted. Keep `OTELBIN_AUTOMATION_ACCOUNT_*` — the CDK deploy step still uses them. Retiring the underlying IAM users is tracked internally.


